### PR TITLE
infra: add docker-compose for neo4j, mongodb, redis (#1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,22 @@
+.vscode/
+.idea/
+.DS_Store
+
+# Env / secrets
+.env
+.env.local
+*.env.local
+
+# Python
+__pycache__/
+*.pyc
+*.pyo
+.venv/
+.uv/
+dist/
+build/
+*.egg-info/
+
+# Node
+node_modules/
+.next/

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -1,0 +1,70 @@
+# dev-team 로컬 인프라
+# 로컬에서 GUI 도구(Neo4j Browser, MongoDB Compass, RedisInsight)로
+# 직접 관찰할 수 있도록 호스트 포트를 노출한다.
+#
+# 사용:
+#   cp .env.example .env   # (이슈 #2에서 제공)
+#   docker compose -f infra/docker-compose.yml --env-file .env up -d
+name: dev-team
+
+services:
+  neo4j:
+    image: neo4j:5
+    container_name: dev-team-neo4j
+    restart: unless-stopped
+    environment:
+      NEO4J_AUTH: "${NEO4J_USER:-neo4j}/${NEO4J_PASSWORD:-devteam_neo4j}"
+      # 필요한 APOC 등 플러그인은 추후 init 단계에서 활성화
+    ports:
+      - "${NEO4J_HTTP_PORT:-7474}:7474"   # Browser (HTTP)
+      - "${NEO4J_BOLT_PORT:-7687}:7687"   # Bolt (driver/GUI)
+    volumes:
+      - neo4j-data:/data
+      - neo4j-logs:/logs
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:7474 >/dev/null 2>&1 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 30s
+
+  mongodb:
+    image: mongo:8
+    container_name: dev-team-mongodb
+    restart: unless-stopped
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: "${MONGO_INITDB_ROOT_USERNAME:-root}"
+      MONGO_INITDB_ROOT_PASSWORD: "${MONGO_INITDB_ROOT_PASSWORD:-devteam_mongo}"
+    ports:
+      - "${MONGO_PORT:-27017}:27017"
+    volumes:
+      - mongodb-data:/data/db
+    healthcheck:
+      test: ["CMD", "mongosh", "--quiet", "--eval", "db.adminCommand('ping').ok"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 20s
+
+  redis:
+    image: redis:8
+    container_name: dev-team-redis
+    restart: unless-stopped
+    # AOF 영속화 활성화 — a2a-events stream 보존
+    command: ["redis-server", "--appendonly", "yes"]
+    ports:
+      - "${REDIS_PORT:-6379}:6379"
+    volumes:
+      - redis-data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 3s
+      retries: 10
+      start_period: 10s
+
+volumes:
+  neo4j-data:
+  neo4j-logs:
+  mongodb-data:
+  redis-data:


### PR DESCRIPTION
## Summary
- `infra/docker-compose.yml` 신규 추가 — Neo4j 5, MongoDB 8, Redis 8
- 각 서비스 호스트 포트 노출 (7474/7687, 27017, 6379) → 로컬 GUI 도구에서 바로 접속 가능
- Named volume으로 데이터 영속화 (`neo4j-data`, `neo4j-logs`, `mongodb-data`, `redis-data`)
- Redis AOF 영속화 활성화 (`--appendonly yes`) — 향후 a2a-events stream 보존 대비
- Healthcheck 3종 (Neo4j HTTP, Mongo `ping`, Redis `ping`)
- `.gitignore` 기본 템플릿 추가 (`.env`, Python 캐시, node_modules 등)

> DHI 이미지(`dhi.io/...`)는 접근 불가 확인되어 public 이미지(`neo4j:5`, `mongo:8`, `redis:8`)로 전환.
> 관련 논의: 이슈 #1 및 논의 기록.

## Scope out (후속 이슈)
- `.env.example` — #2
- Neo4j/MongoDB 초기화 sh 스크립트 — #3
- 로컬 GUI 가이드 문서 — #4

## Test plan
- [x] `docker compose -f infra/docker-compose.yml config` — 문법 검증 통과
- [x] `docker compose -f infra/docker-compose.yml up -d` — 3개 컨테이너 정상 기동
- [x] 3개 전부 `healthy` 상태 도달 확인
- [x] 호스트 포트 매핑 확인 (`docker compose ps`)

```
NAME               IMAGE     STATUS                   PORTS
dev-team-mongodb   mongo:8   Up 3 minutes (healthy)   0.0.0.0:27017->27017/tcp
dev-team-neo4j    neo4j:5   Up 3 minutes (healthy)   0.0.0.0:7474->7474/tcp, 0.0.0.0:7687->7687/tcp
dev-team-redis    redis:8   Up 3 minutes (healthy)   0.0.0.0:6379->6379/tcp
```

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)