### PR TITLE
infra: add .env.example template (#2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,33 @@
+# dev-team 로컬 인프라 환경 변수 템플릿
+#
+# 사용:
+#   cp .env.example .env
+#   # 값을 원하는 대로 수정한 뒤
+#   docker compose -f infra/docker-compose.yml --env-file .env up -d
+#
+# 실제 비밀 값(API 토큰 등)은 이 파일에 쓰지 않습니다.
+# 본 템플릿은 git에 커밋되지만 `.env`는 `.gitignore`로 제외됩니다.
+
+# ---- Neo4j ----
+# Neo4j 기본 사용자는 항상 'neo4j'이며 변경 불가 (Community Edition).
+# 비밀번호는 최소 8자 이상이어야 합니다.
+NEO4J_USER=neo4j
+NEO4J_PASSWORD=devteam_neo4j
+
+# 호스트 노출 포트 (기본: 7474 HTTP / 7687 Bolt)
+NEO4J_HTTP_PORT=7474
+NEO4J_BOLT_PORT=7687
+
+# ---- MongoDB ----
+MONGO_INITDB_ROOT_USERNAME=root
+MONGO_INITDB_ROOT_PASSWORD=devteam_mongo
+
+# 애플리케이션에서 사용할 DB 이름 (초기화 스크립트에서 생성 — #3에서 활용)
+MONGO_APP_DB=dev_team
+
+# 호스트 노출 포트
+MONGO_PORT=27017
+
+# ---- Redis ----
+# Redis는 기본적으로 인증 없이 로컬 바인딩만 됩니다 (dev 용도).
+REDIS_PORT=6379


### PR DESCRIPTION
## Summary
- `.env.example` 템플릿 추가 — `docker compose --env-file .env`가 참조하는 변수들을 정의
- Neo4j / MongoDB 인증 + 호스트 노출 포트 변수 포함
- `MONGO_APP_DB=dev_team` — 후속 이슈 #3의 초기화 스크립트에서 활용 예정
- Redis는 dev 용도로 인증 없이 로컬 바인딩 (포트만 변수화)

> `.gitignore`에 `.env` 제외 항목은 이미 #1에서 커밋됨 — 이 PR에서는 중복 작업 없음.

## Test plan
- [x] `cp .env.example .env` 후 `docker compose --env-file .env config` 로 변수 치환 검증
  - NEO4J_AUTH, MONGO_INITDB_ROOT_* 가 기대대로 렌더링됨
  - published 포트가 기대값(7474/7687/27017/6379)으로 나옴

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)