### PR TITLE
infra: add Neo4j/MongoDB init script skeletons (#3)

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -46,6 +46,40 @@ services:
       retries: 12
       start_period: 20s
 
+  # One-shot: Neo4j healthy 후 스키마(제약·인덱스) 적용 → 종료
+  neo4j-init:
+    image: neo4j:5
+    container_name: dev-team-neo4j-init
+    depends_on:
+      neo4j:
+        condition: service_healthy
+    environment:
+      NEO4J_URI: "bolt://neo4j:7687"
+      NEO4J_USER: "${NEO4J_USER:-neo4j}"
+      NEO4J_PASSWORD: "${NEO4J_PASSWORD:-devteam_neo4j}"
+    volumes:
+      - ./init/neo4j-init.sh:/init.sh:ro
+    entrypoint: ["bash", "/init.sh"]
+    restart: "no"
+
+  # One-shot: MongoDB healthy 후 컬렉션·인덱스 생성 → 종료
+  mongo-init:
+    image: mongo:8
+    container_name: dev-team-mongo-init
+    depends_on:
+      mongodb:
+        condition: service_healthy
+    environment:
+      MONGO_HOST: "mongodb"
+      MONGO_PORT: "27017"
+      MONGO_INITDB_ROOT_USERNAME: "${MONGO_INITDB_ROOT_USERNAME:-root}"
+      MONGO_INITDB_ROOT_PASSWORD: "${MONGO_INITDB_ROOT_PASSWORD:-devteam_mongo}"
+      MONGO_APP_DB: "${MONGO_APP_DB:-dev_team}"
+    volumes:
+      - ./init/mongo-init.sh:/init.sh:ro
+    entrypoint: ["bash", "/init.sh"]
+    restart: "no"
+
   redis:
     image: redis:8
     container_name: dev-team-redis

--- a/infra/init/mongo-init.sh
+++ b/infra/init/mongo-init.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+#
+# MongoDB 초기화 스크립트
+#
+# 적용 대상: proposal.md §4.2 (Episodic Layer)
+#   컬렉션: tasks, sessions, items, technical_notes, design_alternatives
+#   인덱스: 주요 조회 패턴(by_task, by_session, thread) 대응
+#
+# 용도:
+#   1) docker compose의 one-shot init 서비스에서 자동 실행
+#   2) 수동 실행:
+#        MONGO_HOST=localhost MONGO_PORT=27017 \
+#        MONGO_INITDB_ROOT_USERNAME=root \
+#        MONGO_INITDB_ROOT_PASSWORD=devteam_mongo \
+#        MONGO_APP_DB=dev_team \
+#        bash infra/init/mongo-init.sh
+#
+# 요구 바이너리: mongosh (mongo:8 이미지에 기본 포함)
+
+set -euo pipefail
+
+MONGO_HOST="${MONGO_HOST:-mongodb}"
+MONGO_PORT="${MONGO_PORT:-27017}"
+MONGO_USER="${MONGO_INITDB_ROOT_USERNAME:-root}"
+MONGO_PASS="${MONGO_INITDB_ROOT_PASSWORD:?MONGO_INITDB_ROOT_PASSWORD is required}"
+APP_DB="${MONGO_APP_DB:-dev_team}"
+
+echo "[mongo-init] initializing database '${APP_DB}' on ${MONGO_HOST}:${MONGO_PORT} ..."
+
+mongosh --quiet \
+  --host "${MONGO_HOST}" --port "${MONGO_PORT}" \
+  -u "${MONGO_USER}" -p "${MONGO_PASS}" \
+  --authenticationDatabase admin \
+  --eval "
+const appDb = '${APP_DB}';
+const cols = ['tasks', 'sessions', 'items', 'technical_notes', 'design_alternatives'];
+
+const target = db.getSiblingDB(appDb);
+const existing = target.getCollectionNames();
+
+// 1) 컬렉션 생성 (idempotent)
+cols.forEach(function (c) {
+  if (!existing.includes(c)) {
+    target.createCollection(c);
+    print('[mongo-init] created collection: ' + c);
+  } else {
+    print('[mongo-init] exists: ' + c);
+  }
+});
+
+// 2) 인덱스 (createIndex 는 동일 spec 이면 idempotent)
+target.sessions.createIndex({ task_id: 1 });
+target.items.createIndex({ task_id: 1 });
+target.items.createIndex({ session_id: 1 });
+target.items.createIndex({ prev_item_id: 1 });
+target.items.createIndex({ task_id: 1, timestamp: 1 });
+target.technical_notes.createIndex({ task_id: 1 });
+target.design_alternatives.createIndex({ task_id: 1 });
+
+print('[mongo-init] indexes applied.');
+"
+
+echo "[mongo-init] done."

--- a/infra/init/mongo-init.sh
+++ b/infra/init/mongo-init.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
 #
-# MongoDB 초기화 스크립트
+# MongoDB 초기화 스크립트 (뼈대)
 #
-# 적용 대상: proposal.md §4.2 (Episodic Layer)
-#   컬렉션: tasks, sessions, items, technical_notes, design_alternatives
-#   인덱스: 주요 조회 패턴(by_task, by_session, thread) 대응
+# 현재 범위: 접속 확인 + app DB 참조까지.
+# 컬렉션/인덱스 설계는 별도 결정 후 이 스크립트에 추가 예정.
 #
 # 용도:
 #   1) docker compose의 one-shot init 서비스에서 자동 실행
@@ -16,6 +15,9 @@
 #        bash infra/init/mongo-init.sh
 #
 # 요구 바이너리: mongosh (mongo:8 이미지에 기본 포함)
+#
+# 참고: MongoDB 는 데이터베이스를 최초 쓰기 시점에 자동 생성한다.
+#        따라서 별도의 "DB 생성" 단계는 필요 없고, 이 스크립트는 접속 확인만 수행한다.
 
 set -euo pipefail
 
@@ -25,39 +27,11 @@ MONGO_USER="${MONGO_INITDB_ROOT_USERNAME:-root}"
 MONGO_PASS="${MONGO_INITDB_ROOT_PASSWORD:?MONGO_INITDB_ROOT_PASSWORD is required}"
 APP_DB="${MONGO_APP_DB:-dev_team}"
 
-echo "[mongo-init] initializing database '${APP_DB}' on ${MONGO_HOST}:${MONGO_PORT} ..."
-
+echo "[mongo-init] checking connectivity to ${MONGO_HOST}:${MONGO_PORT} (app db: ${APP_DB}) ..."
 mongosh --quiet \
   --host "${MONGO_HOST}" --port "${MONGO_PORT}" \
   -u "${MONGO_USER}" -p "${MONGO_PASS}" \
   --authenticationDatabase admin \
-  --eval "
-const appDb = '${APP_DB}';
-const cols = ['tasks', 'sessions', 'items', 'technical_notes', 'design_alternatives'];
+  --eval "db.getSiblingDB('${APP_DB}').runCommand({ ping: 1 }).ok" >/dev/null
 
-const target = db.getSiblingDB(appDb);
-const existing = target.getCollectionNames();
-
-// 1) 컬렉션 생성 (idempotent)
-cols.forEach(function (c) {
-  if (!existing.includes(c)) {
-    target.createCollection(c);
-    print('[mongo-init] created collection: ' + c);
-  } else {
-    print('[mongo-init] exists: ' + c);
-  }
-});
-
-// 2) 인덱스 (createIndex 는 동일 spec 이면 idempotent)
-target.sessions.createIndex({ task_id: 1 });
-target.items.createIndex({ task_id: 1 });
-target.items.createIndex({ session_id: 1 });
-target.items.createIndex({ prev_item_id: 1 });
-target.items.createIndex({ task_id: 1, timestamp: 1 });
-target.technical_notes.createIndex({ task_id: 1 });
-target.design_alternatives.createIndex({ task_id: 1 });
-
-print('[mongo-init] indexes applied.');
-"
-
-echo "[mongo-init] done."
+echo "[mongo-init] connection OK. (collections/indexes will be added later when designed)"

--- a/infra/init/neo4j-init.sh
+++ b/infra/init/neo4j-init.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# Neo4j 스키마 초기화 스크립트
+#
+# 적용 대상: proposal.md §4.1 (Semantic Layer)
+# - 노드: Interface, Class, PublicMethod, Module, Task, Feature, BugReport
+# - 제약조건 및 인덱스는 CREATE ... IF NOT EXISTS 로 idempotent
+#
+# 용도:
+#   1) docker compose의 one-shot init 서비스에서 자동 실행
+#   2) 수동 실행도 가능 — 필요한 env만 주입
+#        NEO4J_URI=bolt://localhost:7687 \
+#        NEO4J_USER=neo4j \
+#        NEO4J_PASSWORD=devteam_neo4j \
+#        bash infra/init/neo4j-init.sh
+#
+# 요구 바이너리: cypher-shell (neo4j:5 이미지에 기본 포함)
+
+set -euo pipefail
+
+NEO4J_URI="${NEO4J_URI:-bolt://neo4j:7687}"
+NEO4J_USER="${NEO4J_USER:-neo4j}"
+NEO4J_PASSWORD="${NEO4J_PASSWORD:?NEO4J_PASSWORD is required}"
+
+echo "[neo4j-init] applying schema to ${NEO4J_URI} ..."
+
+cypher-shell -a "${NEO4J_URI}" -u "${NEO4J_USER}" -p "${NEO4J_PASSWORD}" <<'CYPHER'
+// --- 제약조건 (고유성) ---
+CREATE CONSTRAINT interface_name_unique  IF NOT EXISTS FOR (i:Interface)    REQUIRE i.name IS UNIQUE;
+CREATE CONSTRAINT class_fqn_unique       IF NOT EXISTS FOR (c:Class)        REQUIRE c.fqn  IS UNIQUE;
+CREATE CONSTRAINT module_path_unique     IF NOT EXISTS FOR (m:Module)       REQUIRE m.path IS UNIQUE;
+CREATE CONSTRAINT task_id_unique         IF NOT EXISTS FOR (t:Task)         REQUIRE t.id   IS UNIQUE;
+CREATE CONSTRAINT feature_id_unique      IF NOT EXISTS FOR (f:Feature)      REQUIRE f.id   IS UNIQUE;
+CREATE CONSTRAINT bugreport_id_unique    IF NOT EXISTS FOR (b:BugReport)    REQUIRE b.id   IS UNIQUE;
+
+// --- 인덱스 (non-unique, 조회 성능용) ---
+CREATE INDEX publicmethod_signature IF NOT EXISTS FOR (p:PublicMethod) ON (p.signature);
+CREATE INDEX class_module            IF NOT EXISTS FOR (c:Class)        ON (c.module);
+CYPHER
+
+echo "[neo4j-init] done."

--- a/infra/init/neo4j-init.sh
+++ b/infra/init/neo4j-init.sh
@@ -1,20 +1,22 @@
 #!/usr/bin/env bash
 #
-# Neo4j 스키마 초기화 스크립트
+# Neo4j 초기화 스크립트 (뼈대)
 #
-# 적용 대상: proposal.md §4.1 (Semantic Layer)
-# - 노드: Interface, Class, PublicMethod, Module, Task, Feature, BugReport
-# - 제약조건 및 인덱스는 CREATE ... IF NOT EXISTS 로 idempotent
+# 현재 범위: 접속 확인만.
+# 스키마(제약/인덱스) 설계는 별도 결정 후 이 스크립트에 추가 예정.
 #
 # 용도:
 #   1) docker compose의 one-shot init 서비스에서 자동 실행
-#   2) 수동 실행도 가능 — 필요한 env만 주입
+#   2) 수동 실행:
 #        NEO4J_URI=bolt://localhost:7687 \
 #        NEO4J_USER=neo4j \
 #        NEO4J_PASSWORD=devteam_neo4j \
 #        bash infra/init/neo4j-init.sh
 #
 # 요구 바이너리: cypher-shell (neo4j:5 이미지에 기본 포함)
+#
+# 참고: Neo4j Community 에디션은 기본 DB(\`neo4j\`)가 자동 생성되며
+#        추가 DB 생성은 Enterprise 에디션 기능이므로 이 스크립트에서 다루지 않는다.
 
 set -euo pipefail
 
@@ -22,20 +24,7 @@ NEO4J_URI="${NEO4J_URI:-bolt://neo4j:7687}"
 NEO4J_USER="${NEO4J_USER:-neo4j}"
 NEO4J_PASSWORD="${NEO4J_PASSWORD:?NEO4J_PASSWORD is required}"
 
-echo "[neo4j-init] applying schema to ${NEO4J_URI} ..."
+echo "[neo4j-init] checking connectivity to ${NEO4J_URI} ..."
+cypher-shell -a "${NEO4J_URI}" -u "${NEO4J_USER}" -p "${NEO4J_PASSWORD}" "RETURN 1 AS ok;" >/dev/null
 
-cypher-shell -a "${NEO4J_URI}" -u "${NEO4J_USER}" -p "${NEO4J_PASSWORD}" <<'CYPHER'
-// --- 제약조건 (고유성) ---
-CREATE CONSTRAINT interface_name_unique  IF NOT EXISTS FOR (i:Interface)    REQUIRE i.name IS UNIQUE;
-CREATE CONSTRAINT class_fqn_unique       IF NOT EXISTS FOR (c:Class)        REQUIRE c.fqn  IS UNIQUE;
-CREATE CONSTRAINT module_path_unique     IF NOT EXISTS FOR (m:Module)       REQUIRE m.path IS UNIQUE;
-CREATE CONSTRAINT task_id_unique         IF NOT EXISTS FOR (t:Task)         REQUIRE t.id   IS UNIQUE;
-CREATE CONSTRAINT feature_id_unique      IF NOT EXISTS FOR (f:Feature)      REQUIRE f.id   IS UNIQUE;
-CREATE CONSTRAINT bugreport_id_unique    IF NOT EXISTS FOR (b:BugReport)    REQUIRE b.id   IS UNIQUE;
-
-// --- 인덱스 (non-unique, 조회 성능용) ---
-CREATE INDEX publicmethod_signature IF NOT EXISTS FOR (p:PublicMethod) ON (p.signature);
-CREATE INDEX class_module            IF NOT EXISTS FOR (c:Class)        ON (c.module);
-CYPHER
-
-echo "[neo4j-init] done."
+echo "[neo4j-init] connection OK. (schema will be added later when designed)"


### PR DESCRIPTION
## Summary
이슈 #3 의 원래 지시 범위("초기 DB 관련 초기화 작업을 sh 스크립트로")에 맞춰 **접속 확인 수준의 뼈대**만 추가합니다. 스키마 설계는 별도 결정 후 이 스크립트에 점진 추가 예정.

## Changes
- `infra/init/neo4j-init.sh` — `cypher-shell`로 접속 확인만 수행
- `infra/init/mongo-init.sh` — `mongosh`로 app DB 접속 ping만 수행
- `docker-compose.yml`에 one-shot 서비스 `neo4j-init`, `mongo-init` 추가
  - 각 DB `service_healthy` 통과 후 실행 → 종료
- 두 스크립트 모두 idempotent

## 범위에서 제외 (후속 이슈로 분리 예정)
- Graph DB 제약조건/인덱스 설계
- MongoDB 컬렉션/인덱스 설계
  → 스키마는 사용자 결정 후 진행

## Test plan
- [x] `docker compose up -d` → init 컨테이너 exit 0 × 2
- [x] 재실행(Idempotency) → 역시 exit 0
- [x] 스크립트 로그에 스키마 관련 출력 없음 (접속 OK만)

## Note
이전 커밋에서 추가됐던 월권 스키마 코드(제약/인덱스/컬렉션 생성)를 걷어내는 후속 커밋이 포함됩니다.
이미 기동 중인 DB 볼륨에 해당 객체들이 남아있을 수 있으므로, 병합 후 `docker compose down -v && up -d`로 초기화 권장.

Closes #3