### PR TITLE
feat(shared/a2a): 위임 시 contextId/traceId 규약 + 인프라 (옵션 B) (#32)

### DIFF
--- a/shared/src/dev_team_shared/a2a/__init__.py
+++ b/shared/src/dev_team_shared/a2a/__init__.py
@@ -15,6 +15,7 @@ from dev_team_shared.a2a.agent_card import (
     build_agent_card,
 )
 from dev_team_shared.a2a.client import A2AClient, A2AClientError
+from dev_team_shared.a2a.tracing import TRACE_ID_HEADER
 from dev_team_shared.a2a.types import Message, Part, TaskState
 
 __all__ = [
@@ -25,6 +26,7 @@ __all__ = [
     "AgentSkill",
     "Message",
     "Part",
+    "TRACE_ID_HEADER",
     "TaskState",
     "build_agent_card",
 ]

--- a/shared/src/dev_team_shared/a2a/client.py
+++ b/shared/src/dev_team_shared/a2a/client.py
@@ -18,6 +18,7 @@ from typing import Any, Literal
 
 import httpx
 
+from dev_team_shared.a2a.tracing import TRACE_ID_HEADER
 from dev_team_shared.a2a.types import Message
 
 MethodStyle = Literal["pascal", "slash"]
@@ -49,6 +50,10 @@ class A2AClient:
             예: `http://architect:9000/a2a/architect`
         method_style: 서버가 지원하는 메서드 명명 스타일. 기본은 A2A v1.0 의 `pascal`.
         timeout: HTTP 타임아웃 (초).
+        trace_id: 본 클라이언트가 모든 호출에 default 로 붙일 trace ID.
+            위임 흐름에서는 매 호출마다 메서드 인자로 override 하는 것이 일반적.
+            None 이면 헤더 미송신 → 수신 서버가 새로 발급. 자세한 규약:
+            `dev_team_shared.a2a.tracing`.
     """
 
     def __init__(
@@ -58,26 +63,49 @@ class A2AClient:
         method_style: MethodStyle = "pascal",
         timeout: float = 30.0,
         http_client: httpx.Client | None = None,
+        trace_id: str | None = None,
     ) -> None:
         self._endpoint = endpoint
         self._style: MethodStyle = method_style
         self._timeout = timeout
         self._owns_client = http_client is None
         self._http = http_client or httpx.Client(timeout=timeout)
+        self._default_trace_id = trace_id
 
     # ------------------------------------------------------------------
     # 공개 API
     # ------------------------------------------------------------------
-    def send_message(self, message: Message, **extra_params: Any) -> dict[str, Any]:
-        """동기 요청-응답. 결과는 `Task` 또는 `Message` (서버 재량)."""
-        return self._call("send_message", self._message_params(message, extra_params))
+    def send_message(
+        self,
+        message: Message,
+        *,
+        trace_id: str | None = None,
+        **extra_params: Any,
+    ) -> dict[str, Any]:
+        """동기 요청-응답. 결과는 `Task` 또는 `Message` (서버 재량).
 
-    def get_task(self, task_id: str, *, history_length: int | None = None) -> dict[str, Any]:
+        `trace_id` 가 주어지면 이 호출에 한해 그 값으로 헤더 송신. 위임자는
+        받은 요청의 trace_id 를 이 인자로 forward 하여 트리 전체를 한 trace 로
+        묶는다.
+        """
+        return self._call(
+            "send_message",
+            self._message_params(message, extra_params),
+            trace_id=trace_id,
+        )
+
+    def get_task(
+        self,
+        task_id: str,
+        *,
+        history_length: int | None = None,
+        trace_id: str | None = None,
+    ) -> dict[str, Any]:
         """이전에 시작된 Task 의 상태/결과 조회."""
         params: dict[str, Any] = {"taskId": task_id}
         if history_length is not None:
             params["historyLength"] = history_length
-        return self._call("get_task", params)
+        return self._call("get_task", params, trace_id=trace_id)
 
     def close(self) -> None:
         if self._owns_client:
@@ -92,7 +120,13 @@ class A2AClient:
     # ------------------------------------------------------------------
     # 내부 구현
     # ------------------------------------------------------------------
-    def _call(self, logical_method: str, params: dict[str, Any]) -> dict[str, Any]:
+    def _call(
+        self,
+        logical_method: str,
+        params: dict[str, Any],
+        *,
+        trace_id: str | None = None,
+    ) -> dict[str, Any]:
         wire_method = _METHOD_MAP[logical_method][self._style]
         payload = {
             "jsonrpc": "2.0",
@@ -100,8 +134,11 @@ class A2AClient:
             "method": wire_method,
             "params": params,
         }
+        # 헤더 우선순위: 메서드 인자 > 생성자 default. 둘 다 없으면 미송신.
+        effective_trace = trace_id or self._default_trace_id
+        headers = {TRACE_ID_HEADER: effective_trace} if effective_trace else None
         try:
-            resp = self._http.post(self._endpoint, json=payload)
+            resp = self._http.post(self._endpoint, json=payload, headers=headers)
             resp.raise_for_status()
         except httpx.HTTPError as e:
             raise A2AClientError(f"HTTP error calling {wire_method}: {e}") from e

--- a/shared/src/dev_team_shared/a2a/messaging.md
+++ b/shared/src/dev_team_shared/a2a/messaging.md
@@ -36,8 +36,10 @@ ID 가 부여되고, `state` 가 lifecycle 을 따라 변하며 (§4 참조), `h
 
 > 비유: Message 가 손님의 **주문서**, Task 가 주방의 **작업 티켓**. 주문서는 한 장 받고 끝, 티켓은 "접수 → 조리 → 완료" 처럼 상태가 변한다.
 
-**`contextId`** — 같은 대화 묶음.
-같은 `contextId` 를 공유하는 여러 Task = 한 다중 turn 대화. 우리 구현은 이를 **LangGraph 의 `thread_id` 로 매핑** 해 체크포인터(Postgres) 가 대화별 state 를 영속화한다 — `graph_handlers/send_message.py` 의 `graph.ainvoke(..., config={"configurable": {"thread_id": ctx.context_id}})` 부분.
+**`contextId`** — **한 에이전트 boundary 안의** 다중 turn 대화 묶음.
+같은 `contextId` 를 공유하는 여러 Task = 한 대화. 우리 구현은 이를 **LangGraph 의 `thread_id` 로 매핑** 해 체크포인터(Postgres) 가 대화별 state 를 영속화한다 — `graph_handlers/send_message.py` 의 `graph.ainvoke(..., config={"configurable": {"thread_id": ctx.context_id}})` 부분.
+
+⚠️ `contextId` 는 **에이전트 쌍 사이의 conversation 식별자**이지 시스템 전체 trace 식별자가 아니다. UG ↔ Primary 의 contextId 와 Primary ↔ Engineer 의 contextId 는 다른 값이어야 한다 (각각 다른 두 당사자의 대화). 시스템 전체를 묶어 추적하려면 **`traceId`** (§5.x) 를 쓴다.
 
 ---
 
@@ -183,23 +185,46 @@ A2A spec 의 불변식: **`SendMessage` / `SendStreamingMessage` 한 호출 = `T
 
 ### 위임은 별도 호출 → 트리
 
-Primary 가 다른 에이전트에게 일을 넘기는 건 **새로운 A2A 호출** 이고 그 호출은 그 호출대로 자기 Task 를 가진다:
+Primary 가 다른 에이전트에게 일을 넘기는 건 **새로운 A2A 호출** 이고 그 호출은 그 호출대로 **자기 Task + 자기 contextId** 를 가진다:
 
 ```mermaid
 sequenceDiagram
-    UG->>Primary: SendMessage("X 해줘")
-    Note over Primary: Task_A (Primary 입장)
-    Primary->>Engineer: SendMessage("이 모듈 구현해")
-    Note over Engineer: Task_B (Engineer 입장)
+    UG->>Primary: SendMessage(contextId=X)<br/>X-A2A-Trace-Id: T
+    Note over Primary: Task_A (contextId=X)
+    Primary->>Engineer: SendMessage(contextId=Y)<br/>X-A2A-Trace-Id: T (forward)
+    Note over Engineer: Task_B (contextId=Y, 별개 대화)
     Engineer-->>Primary: Task_B(COMPLETED)
     Primary-->>UG: Task_A(COMPLETED)
 ```
 
 각 호출 경계에서 **1:1** 이고, 트리는 그 노드들이 모인 결과. `client.py:A2AClient` 가 위임 호출자 역할.
 
+**핵심 — `contextId` 는 forward 하지 않는다**: UG ↔ Primary 의 `X` 와 Primary ↔ Engineer 의 `Y` 는 다른 값. 각 에이전트 boundary 가 자기 대화 namespace 를 가져 체크포인터 thread 가 격리된다. 시스템 전체 추적은 별도의 **`traceId`** 가 책임진다 (§5.x).
+
+### 5.x. `traceId` — 시스템 전체 추적
+
+`contextId` 가 boundary 안의 대화라면, `traceId` 는 boundary 를 **가로지르는** 추적 ID. UG 에서 시작한 한 사용자 요청이 Primary → Engineer → QA 까지 흐를 때 같은 traceId 가 따라다녀 **한 trace 로 묶여 로그 추적이 가능**.
+
+규약 (`tracing.py:TRACE_ID_HEADER`):
+
+| 항목 | 값 |
+|---|---|
+| Wire 위치 | HTTP 헤더 `X-A2A-Trace-Id` |
+| 부재 시 | 서버 (`router.py`) 가 새 UUID 발급 → `request.state.trace_id` 에 보관 |
+| 위임 시 forward | 위임자가 받은 traceId 를 `A2AClient.send_message(..., trace_id=...)` 인자로 그대로 forward |
+| 로그 | `sse_session.start/cancel/end` 모든 로그에 `trace_id=...` 포함 (`session.py:log_session`) |
+
+코드 매핑:
+
+- 서버 수신 — `router.py` 가 헤더 읽음 → `request.state.trace_id` 보관
+- 핸들러 — `ChatContext.create()` 가 자동으로 읽어 `ctx.trace_id` 에 저장
+- 클라이언트 송신 — `A2AClient(trace_id=...)` (생성자 default) 또는 메서드 인자 `send_message(trace_id=...)` (per-call override)
+
+추후 OpenTelemetry `traceparent` 헤더 도입 시 `tracing.py` 가 두 헤더를 모두 인식하도록 확장하면 된다.
+
 ### `contextId` 로 묶이는 다중 turn
 
-같은 `contextId` 의 SendMessage 를 N 번 부르면 → Task 가 N 개 누적되며 같은 LangGraph thread 위에서 history 가 이어진다. "한 발화당 Task 1개" 가 누적되어 "한 대화" 를 이룬다.
+같은 `contextId` 의 SendMessage 를 N 번 부르면 → Task 가 N 개 누적되며 같은 LangGraph thread 위에서 history 가 이어진다. "한 발화당 Task 1개" 가 누적되어 "한 대화" 를 이룬다 (단일 에이전트 boundary 안에서).
 
 ---
 

--- a/shared/src/dev_team_shared/a2a/server/graph_handlers/session.py
+++ b/shared/src/dev_team_shared/a2a/server/graph_handlers/session.py
@@ -33,6 +33,7 @@ class ChatContext:
     """한 번의 RPC 세션이 갖는 식별자 + 관측 메타.
 
     `started` 는 wall-clock 이 아닌 `time.monotonic()` 기준 (시계 보정 영향 없음).
+    `trace_id` 는 시스템 전체 추적용 (참조: `dev_team_shared.a2a.tracing`).
     """
 
     request: Request
@@ -42,6 +43,7 @@ class ChatContext:
     context_id: str
     task_id: str
     artifact_id: str
+    trace_id: str
     started: float = field(default_factory=time.monotonic)
     chunk_count: int = 0
     reason: str = "completed"
@@ -55,6 +57,11 @@ class ChatContext:
         method: str,
         context_id: str,
     ) -> ChatContext:
+        # trace_id 는 router 가 헤더 또는 신규 발급으로 미리 채워둠 (필수).
+        trace_id = getattr(request.state, "trace_id", None)
+        if not trace_id:
+            # 라우터를 거치지 않는 직접 호출 등의 fallback (테스트 / 비정상 경로).
+            trace_id = str(uuid.uuid4())
         return cls(
             request=request,
             rpc_id=rpc_id,
@@ -63,6 +70,7 @@ class ChatContext:
             context_id=context_id,
             task_id=f"{context_id}:{uuid.uuid4()}",
             artifact_id=str(uuid.uuid4()),
+            trace_id=trace_id,
         )
 
 
@@ -76,8 +84,8 @@ async def log_session(ctx: ChatContext) -> AsyncIterator[None]:
     cancel 로그를 추가 출력한 뒤 전파.
     """
     logger.info(
-        "sse_session.start assistant=%s method=%s context_id=%s",
-        ctx.assistant, ctx.method, ctx.context_id,
+        "sse_session.start assistant=%s method=%s context_id=%s trace_id=%s",
+        ctx.assistant, ctx.method, ctx.context_id, ctx.trace_id,
     )
     try:
         yield
@@ -85,17 +93,17 @@ async def log_session(ctx: ChatContext) -> AsyncIterator[None]:
         if ctx.reason == "completed":
             ctx.reason = "client_disconnect"
         logger.info(
-            "sse_session.cancel assistant=%s context_id=%s reason=%s",
-            ctx.assistant, ctx.context_id, ctx.reason,
+            "sse_session.cancel assistant=%s context_id=%s trace_id=%s reason=%s",
+            ctx.assistant, ctx.context_id, ctx.trace_id, ctx.reason,
         )
         raise
     finally:
         duration_ms = int((time.monotonic() - ctx.started) * 1000)
         logger.info(
             "sse_session.end assistant=%s method=%s context_id=%s "
-            "reason=%s duration_ms=%d chunks=%d",
+            "trace_id=%s reason=%s duration_ms=%d chunks=%d",
             ctx.assistant, ctx.method, ctx.context_id,
-            ctx.reason, duration_ms, ctx.chunk_count,
+            ctx.trace_id, ctx.reason, duration_ms, ctx.chunk_count,
         )
 
 

--- a/shared/src/dev_team_shared/a2a/server/router.py
+++ b/shared/src/dev_team_shared/a2a/server/router.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import uuid
 from collections.abc import Sequence
 
 from fastapi import APIRouter, Request
@@ -28,6 +29,7 @@ from dev_team_shared.a2a.jsonrpc import (
     rpc_error_response,
 )
 from dev_team_shared.a2a.server.handler import MethodHandler
+from dev_team_shared.a2a.tracing import TRACE_ID_HEADER
 
 
 def make_a2a_router(
@@ -68,6 +70,12 @@ def make_a2a_router(
 
     @router.post("/a2a/{aid}")
     async def a2a_rpc(aid: str, request: Request):
+        # trace_id: 클라이언트가 보낸 헤더가 우선, 없으면 서버가 발급.
+        # 핸들러는 request.state.trace_id 로 lookup (per-request 데이터).
+        request.state.trace_id = (
+            request.headers.get(TRACE_ID_HEADER) or str(uuid.uuid4())
+        )
+
         try:
             body = await request.json()
         except Exception as exc:

--- a/shared/src/dev_team_shared/a2a/tracing.py
+++ b/shared/src/dev_team_shared/a2a/tracing.py
@@ -1,0 +1,28 @@
+"""A2A 호출 간 trace ID 전파 규약.
+
+`contextId` 는 한 에이전트 boundary 안의 대화 식별자 (spec §6). 시스템 전체
+요청을 묶어 추적하려면 별도의 traceId 가 필요하다. 본 모듈은 그 규약을 정의
+한다.
+
+규약 요약:
+- wire 위치: HTTP 헤더 `X-A2A-Trace-Id`
+- 부재 시: 서버가 새로 발급 (`uuid4`). UG / 외부 진입점에서 누락돼도 시스템
+  안에서 일관 추적.
+- 운반 책임: 클라이언트 (`A2AClient`) 가 송신, 서버 (`make_a2a_router`) 가
+  수신 후 `request.state.trace_id` 로 보관.
+- 위임 시: Primary 등 위임자가 받은 traceId 를 자기 클라이언트 호출에
+  forward → 트리 전체가 같은 trace 로 묶임 (별도 contextId 와는 독립).
+
+참고: 추후 OpenTelemetry `traceparent` 헤더로 교체 / 병행 가능. 그 시점에는
+본 모듈이 두 헤더를 모두 인식하도록 확장.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+TRACE_ID_HEADER: Final[str] = "X-A2A-Trace-Id"
+"""A2A trace ID 운반에 쓰는 HTTP 헤더 이름."""
+
+
+__all__ = ["TRACE_ID_HEADER"]

--- a/shared/tests/test_a2a_traceid.py
+++ b/shared/tests/test_a2a_traceid.py
@@ -1,0 +1,161 @@
+"""traceId 운반 규약 테스트.
+
+대상:
+- `A2AClient` 가 `X-A2A-Trace-Id` 헤더 송신 (생성자 default / 메서드 override).
+- `make_a2a_router` 가 헤더 읽어 `request.state.trace_id` 에 보관.
+  - 헤더 부재 시 새 UUID 발급.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+import pytest
+from dev_team_shared.a2a import A2AClient, TRACE_ID_HEADER
+from dev_team_shared.a2a.types import Message, Part, Role
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+
+from dev_team_shared.a2a.server import make_a2a_router
+from dev_team_shared.a2a.server.handler import MethodHandler
+
+
+def _client(responder, *, trace_id: str | None = None):  # type: ignore[no-untyped-def]
+    transport = httpx.MockTransport(responder)
+    http = httpx.Client(transport=transport)
+    return A2AClient(
+        "http://peer:9000/a2a/peer",
+        http_client=http,
+        trace_id=trace_id,
+    )
+
+
+class TestClientSendsTraceHeader:
+    def test_no_trace_id_means_no_header(self) -> None:
+        seen: dict[str, Any] = {}
+
+        def responder(request: httpx.Request) -> httpx.Response:
+            seen["headers"] = dict(request.headers)
+            return httpx.Response(200, json={"jsonrpc": "2.0", "id": "x", "result": {}})
+
+        with _client(responder) as c:
+            c.send_message(Message(message_id="m", role=Role.USER, parts=[Part(text="hi")]))
+
+        assert TRACE_ID_HEADER not in seen["headers"]
+        assert TRACE_ID_HEADER.lower() not in seen["headers"]
+
+    def test_constructor_default_trace_id_sent(self) -> None:
+        seen: dict[str, Any] = {}
+
+        def responder(request: httpx.Request) -> httpx.Response:
+            seen["headers"] = dict(request.headers)
+            return httpx.Response(200, json={"jsonrpc": "2.0", "id": "x", "result": {}})
+
+        with _client(responder, trace_id="trace-default-1") as c:
+            c.send_message(Message(message_id="m", role=Role.USER, parts=[Part(text="hi")]))
+
+        # httpx normalizes headers to lowercase keys.
+        assert seen["headers"][TRACE_ID_HEADER.lower()] == "trace-default-1"
+
+    def test_per_call_trace_id_overrides_default(self) -> None:
+        seen: dict[str, Any] = {}
+
+        def responder(request: httpx.Request) -> httpx.Response:
+            seen["headers"] = dict(request.headers)
+            return httpx.Response(200, json={"jsonrpc": "2.0", "id": "x", "result": {}})
+
+        with _client(responder, trace_id="trace-default") as c:
+            c.send_message(
+                Message(message_id="m", role=Role.USER, parts=[Part(text="hi")]),
+                trace_id="trace-per-call",
+            )
+
+        assert seen["headers"][TRACE_ID_HEADER.lower()] == "trace-per-call"
+
+    def test_get_task_carries_trace_id(self) -> None:
+        seen: dict[str, Any] = {}
+
+        def responder(request: httpx.Request) -> httpx.Response:
+            seen["headers"] = dict(request.headers)
+            return httpx.Response(
+                200, json={"jsonrpc": "2.0", "id": "x", "result": {"id": "t"}},
+            )
+
+        with _client(responder) as c:
+            c.get_task("TASK-1", trace_id="trace-getx")
+
+        assert seen["headers"][TRACE_ID_HEADER.lower()] == "trace-getx"
+
+
+class _EchoTraceHandler(MethodHandler):
+    """들어온 trace_id 를 그대로 응답으로 돌려주는 테스트용 핸들러."""
+
+    method_name = "EchoTrace"
+
+    async def handle(self, request: Request, rpc_id: Any, params: dict[str, Any]):
+        return JSONResponse(
+            {
+                "jsonrpc": "2.0",
+                "id": rpc_id,
+                "result": {"trace_id": request.state.trace_id},
+            },
+        )
+
+
+def _make_app() -> FastAPI:
+    app = FastAPI()
+    app.state.agent_card = type("Card", (), {"model_dump": lambda self, **_: {}})()
+    app.include_router(make_a2a_router(assistant_id="peer", handlers=[_EchoTraceHandler()]))
+    return app
+
+
+class TestServerReadsTraceHeader:
+    @pytest.mark.asyncio
+    async def test_header_passed_to_request_state(self) -> None:
+        app = _make_app()
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://t",
+        ) as c:
+            r = await c.post(
+                "/a2a/peer",
+                json={"jsonrpc": "2.0", "id": 1, "method": "EchoTrace", "params": {}},
+                headers={TRACE_ID_HEADER: "incoming-trace-7"},
+            )
+        assert r.status_code == 200
+        assert r.json()["result"]["trace_id"] == "incoming-trace-7"
+
+    @pytest.mark.asyncio
+    async def test_missing_header_fallback_to_new_uuid(self) -> None:
+        app = _make_app()
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://t",
+        ) as c:
+            r = await c.post(
+                "/a2a/peer",
+                json={"jsonrpc": "2.0", "id": 1, "method": "EchoTrace", "params": {}},
+            )
+        body = r.json()
+        trace = body["result"]["trace_id"]
+        # UUID4 형태 확인
+        assert isinstance(trace, str)
+        assert len(trace) == 36 and trace.count("-") == 4
+
+    @pytest.mark.asyncio
+    async def test_two_calls_without_header_get_distinct_trace_ids(self) -> None:
+        app = _make_app()
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://t",
+        ) as c:
+            r1 = await c.post(
+                "/a2a/peer",
+                json={"jsonrpc": "2.0", "id": 1, "method": "EchoTrace", "params": {}},
+            )
+            r2 = await c.post(
+                "/a2a/peer",
+                json={"jsonrpc": "2.0", "id": 2, "method": "EchoTrace", "params": {}},
+            )
+        assert r1.json()["result"]["trace_id"] != r2.json()["result"]["trace_id"]
+
+


### PR DESCRIPTION
## Summary

- 신규 `shared/a2a/tracing.py` — `X-A2A-Trace-Id` 헤더 상수 + 운반 규약 docstring.
- 서버: `router.py` 가 헤더 읽음 (없으면 신규 발급) → `request.state.trace_id` 보관 → `ChatContext.trace_id` → lifecycle 로그 (`session.py:log_session`) 에 `trace_id=...` 포함.
- 클라이언트: `A2AClient` 가 생성자 default + 메서드 인자 (per-call override) 로 traceId 헤더 송신 지원.
- 문서: `messaging.md` §2 / §5 보강 + §5.x traceId 규약 신설. 위임 시 contextId 는 forward 안 하고 새로 발급 (옵션 B), traceId 만 forward.
- 단위 테스트 7개 추가 + 기존 53 테스트 유지 (전부 통과).

Closes #32

## 결정 — 옵션 B (위임마다 새 contextId + 별도 traceId)

대안과의 비교는 #32 참조. 핵심 근거:

1. `contextId` 의 spec 의도 = "한 에이전트와의 대화" 단위. Engineer 입장의 "사용자" 는 Primary 이므로 UG 사용자의 contextId 를 그대로 받는 건 의미 미스매치.
2. 같은 contextId 를 forward 하면 "그 thread 에 history 누적" 이라는 잘못된 멘탈 모델 유발 (실제로는 각 에이전트가 자기 체크포인터를 가져 격리됨).
3. 시스템 전체 추적은 트레이싱 표준 (OpenTelemetry traceparent 등) 의 일이지 conversation ID 의 일이 아님.

## 위임 시퀀스 (이번 PR 의 멘탈 모델)

```mermaid
sequenceDiagram
    UG->>Primary: SendMessage(contextId=X)<br/>X-A2A-Trace-Id: T
    Note over Primary: Task_A (contextId=X)
    Primary->>Engineer: SendMessage(contextId=Y)<br/>X-A2A-Trace-Id: T (forward)
    Note over Engineer: Task_B (contextId=Y, 별개 대화)
    Engineer-->>Primary: Task_B(COMPLETED)
    Primary-->>UG: Task_A(COMPLETED)
```

- `X` ≠ `Y`: contextId 는 boundary 안의 식별자, 위임 시 새로 발급
- `T`: 동일 trace 로 트리 전체 묶임 (Primary 가 받은 traceId 를 자기 client 호출에 forward)
- 본 PR 은 traceId **인프라** 까지만. **위임 흐름 자체는 별도 마일스톤** (Engineer / Architect / QA 도입 시).

## Test plan

- [x] `uv run pytest -q` — 53/53 통과 (신규 7 포함)
- [x] docker compose 회귀 — Primary 컨테이너에 trace 헤더 송신 시 lifecycle 로그에 `trace_id=trace-test-abc-123` 출력 확인
- [x] 헤더 부재 시 fallback — 서버가 새 UUID 발급해 로그 출력 확인 (`trace_id=f58e4838-...`)

## 주요 변경 위치

| 파일 | 변경 |
|---|---|
| `shared/src/dev_team_shared/a2a/tracing.py` | 신규 — `TRACE_ID_HEADER` 상수 + 규약 docstring |
| `shared/src/dev_team_shared/a2a/__init__.py` | `TRACE_ID_HEADER` 외부 노출 |
| `shared/src/dev_team_shared/a2a/server/router.py` | 헤더 read + 신규 발급 fallback → `request.state.trace_id` |
| `shared/src/dev_team_shared/a2a/server/graph_handlers/session.py` | `ChatContext.trace_id` 필드 + `log_session` 의 모든 로그에 포함 |
| `shared/src/dev_team_shared/a2a/client.py` | 생성자 + 메서드 단위 `trace_id` 인자 + `X-A2A-Trace-Id` 헤더 송신 |
| `shared/src/dev_team_shared/a2a/messaging.md` | §2 / §5 보강 + §5.x traceId 규약 신설 |
| `shared/tests/test_a2a_traceid.py` | 신규 — client 송신 / server read+fallback 테스트 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
