### PR TITLE
chore: .env.example 에 GitHub token / target 변수 placeholder 추가 (#49)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,3 +43,12 @@ VALKEY_PORT=6379
 # https://console.anthropic.com/settings/keys 에서 발급.
 # 각 에이전트의 overrides/*.yaml 에서 `${ANTHROPIC_API_KEY}` 로 참조됨.
 ANTHROPIC_API_KEY=
+
+# ---- GitHub (M3 sandbox: P 의 IssueTracker / Wiki MCP 가 사용) ----
+# Classic PAT, scopes: `repo` + `project` (+ 선택: `workflow`).
+# https://github.com/settings/tokens 에서 발급.
+GITHUB_TOKEN=
+# 대상 repo 의 owner (org 또는 user 이름) — 예: vonkernel
+GITHUB_TARGET_OWNER=
+# 대상 repo 이름 — 예: guestbook
+GITHUB_TARGET_REPO=


### PR DESCRIPTION
## Summary

M3 의 GitHub 연동 sandbox (`vonkernel/guestbook`) 를 위한 env 변수 placeholder 를 `.env.example` 에 추가. 다른 변수들과 동일한 스타일 (헤더 + 설명 코멘트) 적용.

추가 변수:
- `GITHUB_TOKEN` — Classic PAT (scopes: `repo` + `project`)
- `GITHUB_TARGET_OWNER` — org / user 이름
- `GITHUB_TARGET_REPO` — 대상 repo 이름

실 값은 각자 `.env` 에서 채움. 본 PR 은 placeholder + 설명만 (코드 변경 0줄).

Closes #49

## Test plan

- [x] `cat .env.example` — 새 변수 + 코멘트 정상 표시
- [x] trailing newline 존재 확인
- [x] 기존 변수들 (Postgres / Anthropic 등) 영향 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)