### PR TITLE
feat(mcp): Document DB MCP 서버 (Postgres dev_team + JSONB + streamable HTTP) (#35)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,47 @@
 - "그냥 지금만 필요해서 섞어 씀" → 나중에 두 번째 유사 사례가 생기면 **즉시
   추상화 분리** (YAGNI 와 균형: 단일 사용엔 추상화 금지, 2번째 등장 시 추상화).
 
+## 모듈 코드 구조 (Python 패키지 공통)
+
+새 Python 모듈 (에이전트 / MCP 서버 / shared 서브 모듈) 작성 시 다음 구조 따른다.
+
+- **책임별 디렉터리 분리**:
+  - `schemas/` — Pydantic 모델만 (DTO / validation)
+  - `repositories/` — 외부 자원 CRUD (DB / HTTP / file). ABC + concrete 한 쌍씩
+  - `tools/` 또는 `handlers/` — 외부 노출 인터페이스 (MCP tool / FastAPI route 등)
+  - 1 파일 1 책임. 200줄 넘으면 분리 신호.
+- **Repository 패턴 (DIP / OCP)**:
+  - `AbstractRepository[T]` ABC 가 generic CRUD 계약 (`upsert`, `get`, `list`, `delete`, `count`)
+  - collection / entity 별 concrete 클래스. 새 entity = 새 파일 1개 (schemas/X + repositories/X + tools/X) + 등록 1줄. **기존 코드 무수정 (OCP)**
+  - 외부 노출 함수 (tools/handlers) 는 repository 만 호출. 직접 driver (`asyncpg`, `httpx`) 호출 금지
+- **DI via lifespan**:
+  - 외부 자원 (DB pool, MCP client, LLM 등) 은 lifespan 에서 생성 → `app.state` 또는 의존성 주입으로 전달
+  - 모듈 레벨 전역 변수 / 싱글턴 금지 (테스트성 ↓)
+- **Schema validation**:
+  - 입력 / 출력 모두 Pydantic 모델로 한 번씩 통과
+  - DB row → Pydantic 직렬화는 repository 가 책임 (raw dict 가 외부로 새지 않게)
+- **테스트 분리**:
+  - Repository 단위 = `testcontainers` 로 실 인프라 (Postgres / Neo4j / Valkey)
+  - Tool / handler 단위 = Repository mock (실 인프라 없이 빠르게)
+  - 통합 = 컨테이너 기동 후 wire-level 호출 (HTTP / MCP)
+- **AI 에이전트 런타임 자산**:
+  - LLM 컨텍스트에 embed 되는 prompt 자료 (가이드 / 템플릿 / 예시) 는 `agents/{name}/resources/` 하위
+  - 이미지 빌드 시 `COPY` 로 컨테이너에 포함. 수정 = 컨테이너 재배포 (자산 변경 = 행동 변경 추적)
+  - 사람이 읽는 설계 문서는 `docs/`, AI 에이전트 운영 규약은 `CLAUDE.md`, **에이전트 자체의 prompt 자료는 `resources/`** — 셋 모두 다른 카테고리
+
+## 포트 컨벤션
+
+호스트 노출 포트의 의미적 대역. 새 컨테이너 추가 시 따른다.
+
+| 대역 | 용도 |
+|---|---|
+| 5000~7999 | 인프라 (Postgres / Valkey / Neo4j 등) |
+| 8000~8099 | 사용자 facing (UG 등) |
+| 9000~9099 | **에이전트 컨테이너** (primary=9001, librarian=9002, architect=9003, ...) |
+| 9100~9199 | **MCP 서버** (document-db=9100, issue-tracker=9101, wiki=9102, graph-db=9103, ...) |
+
+새 에이전트 / MCP 추가 시 같은 대역 안에서 sequential 할당. 변경 시 본 표 즉시 갱신.
+
 ## 범위 / 지시 준수
 
 - **시키지 않은 것은 하지 말 것.** 사용자의 지적을 과잉 해석해 스펙 밖 코드

--- a/agents/primary/resources/wiki-authoring-guide.md
+++ b/agents/primary/resources/wiki-authoring-guide.md
@@ -1,0 +1,235 @@
+# Wiki Authoring Guide (Primary)
+
+Primary 에이전트가 위키 페이지 (`wiki_pages` collection) 를 만들 때 따르는 가이드.
+부팅 시 LLM persona 컨텍스트에 embed 됨 — 사람용 튜토리얼이 아닌 **에이전트용
+prompt 자료**.
+
+`page_type` enum 의 catalog 자체는 [`docs/document-db-schema.md`](../../../docs/document-db-schema.md)
+의 §5 가 root of truth. 본 가이드는 **각 type 을 어떻게 작성하느냐** 에 집중.
+
+---
+
+## 0. 공통 작성 원칙
+
+- **헤더 깊이 ≤ H4** — H5 / H6 는 새 페이지로 분리
+- **Mermaid 다이어그램** — `flowchart` / `sequenceDiagram` / `classDiagram` 등.
+  ASCII 도식 금지 (root CLAUDE.md 의 다이어그램 규칙)
+- **표 / 리스트 활용** — 산문보다 구조화된 표현 우선
+- **References 섹션 필수** — 관련 issue / 다른 wiki 명시
+- **slug** — kebab-case, URL-friendly. 예: `prd-guestbook`, `business-rule-message-length`
+- **structured 필드** — type 별 정의된 구조화 데이터 (마크다운 본문과 별개로 기계가 쿼리)
+
+---
+
+## 1. `prd` — Product Requirements Document
+
+**언제**: 한 프로젝트의 전체 요구사항을 첫 정리할 때. 프로젝트당 보통 1개.
+
+**표준 섹션**:
+
+```markdown
+# {프로젝트명} — PRD
+
+## 배경
+(왜 만드는가, 사용자 누구, 해결하려는 문제)
+
+## 목표
+(이 프로젝트로 달성하려는 것 — bullet list)
+
+## 비-목표
+(명시적으로 안 다룰 것 — 스코프 통제)
+
+## 사용자 시나리오
+(주요 user flow 1~3개)
+
+## 기능 요구사항
+(Epic / Story 단위로 분해 — 본 PRD 가 reference, 실 entity 는 issues 테이블)
+
+## 비기능 요구사항
+(성능 / 가용성 / 보안 / 운영 — 해당 시)
+
+## 마일스톤
+(M1 / M2 ... 또는 1차 / 2차 일정)
+
+## References
+- 관련 Story id 들
+```
+
+**`structured` 필드 (JSONB)**:
+```json
+{
+  "milestones": [{"name": "M1", "description": "..."}],
+  "user_personas": ["사용자 유형 1", ...],
+  "in_scope": [...],
+  "out_of_scope": [...]
+}
+```
+
+---
+
+## 2. `business_rule` — 비즈니스 정책 / 규칙
+
+**언제**: PRD 에 한 줄로 적기엔 디테일이 필요한 정책 / 규칙. 예: "메시지 글자 수 제한", "익명 사용자 허용 여부".
+
+**표준 섹션**:
+
+```markdown
+# {규칙명}
+
+## 규칙
+(한 문장 or 짧은 단락으로 명료히)
+
+## 근거
+(왜 이 규칙이 필요한가)
+
+## 예외 / 경계
+(예외 케이스, 적용되지 않는 경우)
+
+## 영향받는 entities
+(어떤 데이터 / 기능에 영향)
+
+## 검증 방법
+(이 규칙이 지켜지는지 어떻게 확인)
+
+## References
+- 관련 PRD / 다른 business_rule
+```
+
+**`structured` 필드**:
+```json
+{
+  "rule_id": "BR-001",
+  "applies_to": ["messages", "users"],
+  "severity": "must" | "should" | "may"
+}
+```
+
+---
+
+## 3. `data_model` — 데이터 모델
+
+**언제**: P 가 사용자와 대화로 정해진 entity / 필드 / 관계의 초기본. **A 가 M4 에서 정밀화** (라이브러리 / 인덱스 / 제약 등 추가).
+
+**표준 섹션**:
+
+```markdown
+# {도메인명} — 데이터 모델
+
+## 개요
+(이 도메인이 다루는 것 1단락)
+
+## Entity 다이어그램
+
+```mermaid
+classDiagram
+    class Message {
+        +UUID id
+        +String name
+        +String body
+        +Timestamp created_at
+    }
+```
+
+## Entities
+(각 entity 별 필드 / 의미 / 제약 — 표 또는 리스트)
+
+## 관계
+(어떻게 연결되는지)
+
+## References
+- 관련 PRD / business_rule
+```
+
+**`structured` 필드**:
+```json
+{
+  "entities": [
+    {
+      "name": "Message",
+      "fields": [{"name": "id", "type": "UUID", "constraints": ["pk"]}, ...]
+    }
+  ],
+  "relationships": [
+    {"from": "Message", "to": "User", "type": "many_to_one"}
+  ]
+}
+```
+
+---
+
+## 4. `glossary` — 용어집
+
+**언제**: 프로젝트 도메인 용어가 5개 이상 쌓이거나 사용자와 P 간 용어 합의가 필요할 때.
+
+**표준 섹션**:
+
+```markdown
+# {도메인} — Glossary
+
+| 용어 | 정의 | 동의어 | 관련 |
+|---|---|---|---|
+| Guestbook | 방문자가 이름과 메시지를 남길 수 있는 페이지 | 방명록 | Message |
+| Message | 한 방문자가 남긴 한 줄 텍스트 | post, entry | User |
+```
+
+**`structured` 필드**:
+```json
+{
+  "terms": [
+    {"term": "Guestbook", "definition": "...", "synonyms": ["방명록"]}
+  ]
+}
+```
+
+---
+
+## 5. `generic` — 자유 페이지
+
+**언제**: 위 카테고리 어디에도 안 맞는 자유 형식 문서. 임시 메모 / 회의록 / 기타.
+
+**표준 섹션**: 없음. 자유. 단 헤더 / mermaid / references 공통 원칙은 적용.
+
+**`structured` 필드**: `{}` (비움)
+
+---
+
+## 6. 작성 시 결정 흐름
+
+```mermaid
+flowchart TD
+    Start([사용자 요청 도착]) --> Need{wiki 페이지<br/>필요한가?}
+    Need -->|이슈로 충분| Issue[issue 만 생성]
+    Need -->|디테일 필요| Type{어느 type?}
+    Type -->|전체 요구사항 정리| PRD[prd]
+    Type -->|정책/규칙| BR[business_rule]
+    Type -->|데이터 구조| DM[data_model]
+    Type -->|용어 정리| GL[glossary]
+    Type -->|위 어디도 X| GE[generic]
+    PRD --> Draft[draft 저장 → 사용자 컨펌]
+    BR --> Draft
+    DM --> Draft
+    GL --> Draft
+    GE --> Draft
+    Draft --> Sync[confirmed → external sync]
+```
+
+---
+
+## 7. M4 / M5+ 에서 추가될 type
+
+본 가이드는 **Primary 가 작성하는 type 만** 다룸. 다음은 M4 의 `agents/architect/resources/wiki-authoring-guide.md` 가 다룰 type:
+
+- `adr` — Architecture Decision Record (A)
+- `api_contract` — API 계약 (A)
+- `runbook` — 운영 절차 (A 또는 운영자)
+
+P 도 위 type 의 페이지를 **읽을 수 있어야** 한다 (Wiki MCP 의 `get_page` / `list_pages`). 작성은 A 의 책임.
+
+---
+
+## 8. 절대 규칙
+
+- **page_type enum 외의 type 사용 금지** — 새 type 도입은 schema 변경이며 별 이슈 + 사용자 컨펌 필요
+- **slug 는 한 번 정해지면 변경 X** — 외부 sync 후 URL 안정성. 변경 시 redirect 정책 별도 결정
+- **사용자 컨펌 없이 status 를 confirmed 로 두지 않는다** — 모든 새 페이지는 `draft` 로 시작
+- **structured 필드는 자유 폼 X** — type 별 정의된 schema 따름. content_md 와 일관 유지

--- a/docs/document-db-schema.md
+++ b/docs/document-db-schema.md
@@ -1,0 +1,241 @@
+# Document DB Schema (`dev_team` DB)
+
+본 문서는 PostgreSQL `dev_team` DB 의 스키마를 정의한다. 실제 마이그레이션은
+`mcp/document-db/migrations/` 의 SQL 파일이며, 본 문서는 **결정 의도 + 컬럼별
+의미 + 인덱스 근거** 를 함께 기록한다.
+
+`langgraph` DB 와는 같은 인스턴스의 다른 DB 로 분리되어 있다 (이슈 #20).
+
+---
+
+## 0. 명명 / 통일 규약
+
+- **테이블 / 컬럼**: `snake_case`
+- **PK**: 모두 `id UUID DEFAULT gen_random_uuid()` (Postgres `pgcrypto` 또는 `uuid-ossp`)
+- **시간**: 모두 `TIMESTAMPTZ`. `created_at` / `updated_at` 두 컬럼 default `NOW()`
+- **JSONB 컬럼**: GIN 인덱스로 path 쿼리 가능
+- **enum 류**: TEXT + CHECK 제약 (Postgres native ENUM 은 ALTER 비용 큼)
+- **외부 도구 mirror**: `external_refs JSONB DEFAULT '{}'` + `last_synced_at TIMESTAMPTZ`
+- **status lifecycle**: `draft | confirmed | cancelled` (TEXT + CHECK)
+
+---
+
+## 1. `agent_tasks` — 작업 단위
+
+**역할**: 에이전트가 처리하는 한 단위 일. Chronicler 의 Task 계층 (proposal §2.6) 그대로. 모든 다른 entity (issue / wiki / session) 의 묶음 키.
+
+```sql
+CREATE TABLE agent_tasks (
+    id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    title         TEXT NOT NULL,
+    description   TEXT,
+    status        TEXT NOT NULL DEFAULT 'open'
+                  CHECK (status IN ('open', 'in_progress', 'done', 'cancelled')),
+    owner_agent   TEXT,                    -- 'primary' | 'architect' | ...
+    issue_refs    UUID[] NOT NULL DEFAULT '{}',  -- issues.id 의 array
+    metadata      JSONB NOT NULL DEFAULT '{}',
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_agent_tasks_status   ON agent_tasks (status);
+CREATE INDEX idx_agent_tasks_owner    ON agent_tasks (owner_agent);
+CREATE INDEX idx_agent_tasks_issues   ON agent_tasks USING GIN (issue_refs);
+```
+
+| 컬럼 | 의미 |
+|---|---|
+| `status` | 작업 진행 상태. `open` (생성됨, 시작 전) / `in_progress` / `done` / `cancelled` |
+| `owner_agent` | 현재 책임 에이전트. 위임 시 갱신 |
+| `issue_refs` | 본 task 가 처리하는 외부 issue 들 (FK 가 아닌 array — issue 가 여러 task 에 걸칠 수 있음) |
+| `metadata` | 자유 확장. 검색되지 않을 메타데이터 |
+
+---
+
+## 2. `agent_sessions` — 대화 흐름
+
+**역할**: 한 agent_task 안에서 진행되는 한 대화 흐름 (proposal §2.6 Session). A2A `contextId` 와 1:1.
+
+```sql
+CREATE TABLE agent_sessions (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    agent_task_id   UUID NOT NULL REFERENCES agent_tasks(id) ON DELETE CASCADE,
+    initiator       TEXT NOT NULL,          -- 'user' | 'primary' | 'architect' | ...
+    counterpart     TEXT NOT NULL,
+    context_id      TEXT NOT NULL,          -- A2A contextId
+    trace_id        TEXT,                   -- 시스템 전체 추적 (#32)
+    topic           TEXT,                   -- 자유 라벨
+    metadata        JSONB NOT NULL DEFAULT '{}',
+    started_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    ended_at        TIMESTAMPTZ
+);
+
+CREATE INDEX idx_agent_sessions_task    ON agent_sessions (agent_task_id, started_at);
+CREATE INDEX idx_agent_sessions_context ON agent_sessions (context_id);
+CREATE INDEX idx_agent_sessions_trace   ON agent_sessions (trace_id);
+```
+
+| 컬럼 | 의미 |
+|---|---|
+| `initiator` / `counterpart` | A2A 호출의 양 끝. user / primary / architect / ... |
+| `context_id` | A2A `Message.contextId` — 한 boundary 안의 conversation |
+| `trace_id` | 시스템 전체 추적 ID (#32 의 `X-A2A-Trace-Id` 헤더) |
+| `ended_at` | session 종료 시각. NULL 이면 진행 중 |
+
+L 의 `get_chronicler_log_by_context(context_id)` 는 이 테이블 lookup → 해당 session 의 items 반환.
+
+---
+
+## 3. `agent_items` — 개별 메시지
+
+**역할**: session 안의 한 메시지 (proposal §2.6 Item). prev_item_id 로 시간순 chain.
+
+```sql
+CREATE TABLE agent_items (
+    id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    agent_session_id  UUID NOT NULL REFERENCES agent_sessions(id) ON DELETE CASCADE,
+    prev_item_id      UUID REFERENCES agent_items(id),
+    role              TEXT NOT NULL
+                      CHECK (role IN ('user', 'agent', 'system')),
+    sender            TEXT NOT NULL,         -- 구체 발신자 ('primary' / 'architect' / 'user' 등)
+    content           JSONB NOT NULL,        -- A2A Message.parts 그대로
+    message_id        TEXT,                  -- 원본 A2A messageId (디버그용)
+    metadata          JSONB NOT NULL DEFAULT '{}',
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_agent_items_session    ON agent_items (agent_session_id, created_at);
+CREATE INDEX idx_agent_items_prev       ON agent_items (prev_item_id);
+```
+
+| 컬럼 | 의미 |
+|---|---|
+| `prev_item_id` | 이전 item — 대화 순서 추적 |
+| `role` | A2A `Message.role` 매핑 (user / agent / system) |
+| `sender` | 어느 에이전트 / 사용자 |
+| `content` | A2A `Message.parts` 의 JSON 직렬 (text / data / etc) |
+
+---
+
+## 4. `issues` — 외부 이슈 트래커 mirror
+
+**역할**: 사용자가 컨펌한 Epic / Story / Task. document db 가 본질, GitHub Issue 등 외부 도구로 단방향 sync (C2 결정).
+
+```sql
+CREATE TABLE issues (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    agent_task_id   UUID REFERENCES agent_tasks(id),
+    type            TEXT NOT NULL
+                    CHECK (type IN ('epic', 'story', 'task')),
+    title           TEXT NOT NULL,
+    body_md         TEXT NOT NULL,
+    status          TEXT NOT NULL DEFAULT 'draft'
+                    CHECK (status IN ('draft', 'confirmed', 'cancelled')),
+    parent_issue_id UUID REFERENCES issues(id),
+    labels          TEXT[] NOT NULL DEFAULT '{}',
+    external_refs   JSONB NOT NULL DEFAULT '{}',
+    last_synced_at  TIMESTAMPTZ,
+    metadata        JSONB NOT NULL DEFAULT '{}',
+    version         INT NOT NULL DEFAULT 1,    -- optimistic concurrency
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_issues_task          ON issues (agent_task_id);
+CREATE INDEX idx_issues_type_status   ON issues (type, status);
+CREATE INDEX idx_issues_parent        ON issues (parent_issue_id);
+CREATE INDEX idx_issues_external      ON issues USING GIN (external_refs);
+```
+
+| 컬럼 | 의미 |
+|---|---|
+| `type` | `epic` / `story` / `task` — C3 결정. 어댑터별 매핑 (GitHub = label) |
+| `status` | `draft` (대화 중) → `confirmed` (사용자 컨펌, external sync 완료) → `cancelled` |
+| `parent_issue_id` | Epic → Story 계층 |
+| `labels` | 자유 라벨 array |
+| `external_refs` | `{"github": {"issue_number": 1, "node_id": "..."}}` 형식 |
+| `version` | optimistic concurrency. update 시 `WHERE version = ? AND id = ?` |
+
+---
+
+## 5. `wiki_pages` — 위키 문서 mirror
+
+**역할**: 사용자가 컨펌한 위키 문서 (PRD / ADR / business_rule 등). 본질은 db, GitHub Wiki 로 단방향 sync.
+
+```sql
+CREATE TABLE wiki_pages (
+    id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    agent_task_id       UUID REFERENCES agent_tasks(id),
+    page_type           TEXT NOT NULL
+                        CHECK (page_type IN (
+                            'prd', 'business_rule', 'data_model',
+                            'adr', 'api_contract',
+                            'glossary', 'runbook', 'generic'
+                        )),
+    slug                TEXT NOT NULL UNIQUE,
+    title               TEXT NOT NULL,
+    content_md          TEXT NOT NULL,
+    status              TEXT NOT NULL DEFAULT 'draft'
+                        CHECK (status IN ('draft', 'confirmed', 'cancelled')),
+    author_agent        TEXT,
+    references_issues   UUID[] NOT NULL DEFAULT '{}',
+    references_pages    UUID[] NOT NULL DEFAULT '{}',
+    structured          JSONB NOT NULL DEFAULT '{}',
+    external_refs       JSONB NOT NULL DEFAULT '{}',
+    last_synced_at      TIMESTAMPTZ,
+    metadata            JSONB NOT NULL DEFAULT '{}',
+    version             INT NOT NULL DEFAULT 1,
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_wiki_pages_type_status   ON wiki_pages (page_type, status);
+CREATE INDEX idx_wiki_pages_task          ON wiki_pages (agent_task_id);
+CREATE INDEX idx_wiki_pages_external      ON wiki_pages USING GIN (external_refs);
+CREATE INDEX idx_wiki_pages_refs_issues   ON wiki_pages USING GIN (references_issues);
+CREATE INDEX idx_wiki_pages_refs_pages    ON wiki_pages USING GIN (references_pages);
+```
+
+| 컬럼 | 의미 |
+|---|---|
+| `page_type` | 문서 분류. 각 type 별 작성 가이드는 작성 주체 에이전트의 `resources/wiki-authoring-guide.md` |
+| `slug` | URL-friendly id. wiki path 와 매핑. UNIQUE |
+| `content_md` | 사람이 읽는 markdown 본문 |
+| `structured` | type 별 구조화 데이터 (예: ADR 의 alternatives, data_model 의 entities). 기계 쿼리용 |
+| `references_issues` | 관련 issue id array |
+| `references_pages` | 관련 wiki page id array |
+| `version` | optimistic concurrency |
+
+### `page_type` enum
+
+| type | 작성 주체 | 비고 |
+|---|---|---|
+| `prd` | P | Product Requirements Document. 한 프로젝트 1개 |
+| `business_rule` | P | 비즈니스 정책 / 규칙 |
+| `data_model` | P, A | 데이터 모델. P 가 초기본, A 가 정밀화 |
+| `adr` | A | Architecture Decision Record |
+| `api_contract` | A | API 계약 |
+| `glossary` | P, A | 용어집 |
+| `runbook` | A | 운영 절차 |
+| `generic` | 모두 | 위 카테고리 외 |
+
+---
+
+## 6. 향후 확장 (M5+)
+
+- `agent_tasks` 의 sub-task hierarchy (parent_task_id) — A 가 Eng/QA 배분 시
+- `prds` 의 versioning (full history) — 현재는 단일 row 갱신
+- 풀텍스트 검색 (`tsvector` 컬럼) — wiki / item content
+- `audit_log` 테이블 — 모든 entity 의 변경 이력
+
+---
+
+## 7. 마이그레이션 파일 매핑
+
+| 파일 | 다루는 entities |
+|---|---|
+| `001_chronicler.sql` | agent_tasks, agent_sessions, agent_items |
+| `002_issues.sql` | issues |
+| `003_wiki_pages.sql` | wiki_pages |
+
+각 파일은 forward + rollback step 모두 포함. yoyo-migrations 가 `_yoyo_migration` 테이블로 적용 상태 추적.

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -112,10 +112,13 @@ services:
   #  - 각 에이전트가 자체 FastAPI 서버로 A2A 엔드포인트 노출 (primary_agent.server:app)
   #  - 영속성: OSS langgraph-checkpoint-postgres 의 AsyncPostgresSaver 를
   #    lifespan 단계에서 DATABASE_URI 로 wiring
-  #  - 호스트 포트 규약: Primary 9001 / Architect 9002 / Librarian 9003 ...
+  #  - 호스트 포트 규약 (root CLAUDE.md "포트 컨벤션" 참조):
+  #      9000~9099 에이전트 — Primary 9001 / Librarian 9002 / Architect 9003 ...
+  #      9100~9199 MCP    — Document DB 9100 / IssueTracker 9101 / Wiki 9102 / Graph DB 9103
   #
   #  기동:
   #    docker compose -f infra/docker-compose.yml --env-file .env --profile agents up -d
+  #    (MCP 만:  --profile mcp)
 
   primary:
     profiles: ["agents"]
@@ -135,6 +138,29 @@ services:
       - ../overrides/primary.yaml:/app/primary/config/override.yaml:ro
     ports:
       - "9001:8000"                                 # 호스트 9001 ← 컨테이너 8000 (uvicorn)
+    depends_on:
+      postgres:
+        condition: service_healthy
+      postgres-init:
+        condition: service_completed_successfully
+
+  # MCP 서버군 (profile: mcp 또는 agents).
+  # 모든 MCP 는 streamable HTTP transport (MCP spec 2025-06-18). 컨테이너 내부 8000.
+
+  document-db-mcp:
+    profiles: ["mcp", "agents"]
+    build:
+      context: ..
+      dockerfile: mcp/document-db/Dockerfile
+    image: dev-team/document-db-mcp:latest
+    container_name: dev-team-document-db-mcp
+    restart: unless-stopped
+    environment:
+      # dev_team DB DSN (langgraph DB 와 분리, 이슈 #20)
+      DATABASE_URI: "postgres://${POSTGRES_USER:-devteam}:${POSTGRES_PASSWORD:-devteam_postgres}@postgres:5432/${APP_DB:-dev_team}"
+      AUTO_MIGRATE: "true"
+    ports:
+      - "9100:8000"                                 # 호스트 9100 ← 컨테이너 8000
     depends_on:
       postgres:
         condition: service_healthy

--- a/mcp/CLAUDE.md
+++ b/mcp/CLAUDE.md
@@ -1,0 +1,278 @@
+# MCP 서버 — 공통 작업 규약
+
+본 디렉터리 (`mcp/*`) 의 모든 MCP 서버가 따르는 골격. AI 에이전트 / 인간 모두
+새 MCP 서버 작성 / 수정 시 본 문서 + root `CLAUDE.md` + `mcp/<name>/CLAUDE.md`
+세 계층을 함께 따른다.
+
+**Reference 구현**: `mcp/document-db/` — 본 문서의 패턴이 처음 적용된 사례.
+새 MCP 작성 시 디렉터리 구조 / 파일 명명을 그대로 본떠도 무방.
+
+---
+
+## 1. 모든 MCP 공통 골격 (고정)
+
+### 1.1. 디렉터리 구조
+
+```
+mcp/<name>/
+├── CLAUDE.md                          # 본 모듈 한정 작업 규약
+├── pyproject.toml                     # 의존 + dev extras
+├── Dockerfile                         # python:3.13-slim 기반
+├── src/<name>_mcp/
+│   ├── __init__.py
+│   ├── mcp_instance.py                # FastMCP 싱글턴 + lifespan + AppContext
+│   ├── server.py                      # entry point (얇음)
+│   ├── config.py                      # pydantic-settings env 로딩
+│   ├── schemas/                       # Pydantic Create / Update / Read
+│   │   ├── __init__.py
+│   │   └── <entity>.py
+│   ├── tools/                         # MCP 도구
+│   │   ├── __init__.py                # side-effect import
+│   │   └── <entity>.py                # module-level @mcp.tool()
+│   └── [repositories/ 또는 adapters/]  # backend 따라 (§2 참조)
+└── tests/
+    ├── __init__.py
+    ├── test_schemas.py
+    └── test_<repos|adapters>.py
+```
+
+### 1.2. FastMCP 인스턴스 (`mcp_instance.py`)
+
+- `FastMCP(name=, lifespan=, host="0.0.0.0", port=, transport_security=...)` 모듈 레벨 싱글턴
+- `lifespan` 이 **`AppContext` dataclass yield** (이름 통일)
+- AppContext 는 collection / adapter 별 instance 묶음 (frozen dataclass)
+- 도구는 `ctx.request_context.lifespan_context.<X>` 로 접근
+
+```python
+@dataclass(frozen=True)
+class AppContext:
+    foo: FooRepository  # 또는 FooAdapter
+    bar: BarRepository
+
+@asynccontextmanager
+async def _app_lifespan(_server: FastMCP) -> AsyncIterator[AppContext]:
+    settings = Settings()
+    # ...자원 생성...
+    yield AppContext(foo=..., bar=...)
+
+mcp = FastMCP(
+    "<name>",
+    lifespan=_app_lifespan,
+    host="0.0.0.0",
+    port=settings.http_port,
+    transport_security=TransportSecuritySettings(enable_dns_rebinding_protection=False),
+)
+```
+
+### 1.3. 도구 등록 패턴 (`tools/`)
+
+- **module-level `@mcp.tool()` 데코레이터** — 함수가 `ctx: Context` 를 첫 인자로 받음
+- `tools/__init__.py` 가 모든 collection 모듈을 side-effect import → 등록 트리거
+
+```python
+# tools/<entity>.py
+from mcp.server.fastmcp import Context
+from <name>_mcp.mcp_instance import AppContext, mcp
+
+def _ctx(ctx: Context) -> AppContext:
+    return ctx.request_context.lifespan_context  # type: ignore[return-value]
+
+@mcp.tool(name="<entity>.upsert", description="...")
+async def upsert(ctx: Context, doc: dict[str, Any]) -> dict[str, Any]:
+    repo = _ctx(ctx).<entity>
+    return (await repo.create(<Entity>Create.model_validate(doc))).model_dump(mode="json")
+```
+
+```python
+# tools/__init__.py
+from <name>_mcp.tools import (  # noqa: F401  side-effect imports
+    entity_a,
+    entity_b,
+)
+```
+
+### 1.4. Entry point (`server.py`)
+
+얇음. 도구 등록 trigger + `mcp.run("streamable-http")`.
+
+```python
+from <name>_mcp import tools as _tools  # noqa: F401  registers tools
+from <name>_mcp.mcp_instance import mcp
+
+def main() -> None:
+    mcp.run(transport="streamable-http")
+
+if __name__ == "__main__":
+    main()
+```
+
+### 1.5. 5 op 표준 도구 면
+
+CRUD-able entity 마다 동일한 5 op:
+
+| 도구 | 시그니처 |
+|---|---|
+| `<entity>.upsert` | `(doc, id?, expected_version?) → dict` |
+| `<entity>.get` | `(id) → dict \| null` |
+| `<entity>.list` | `(where?, limit, offset, order_by) → list[dict]` |
+| `<entity>.delete` | `(id) → bool` |
+| `<entity>.count` | `(where?) → int` |
+
+추가 query 가 필요하면 collection 별 특수 도구 (예: `wiki_page.get_by_slug`) — 항상 5 op 위에 누적.
+
+Immutable entity (audit log 류) 는 update / upsert 미노출.
+
+---
+
+## 2. Backend 변형
+
+### 2.1. DB-backed (Document DB / Graph DB)
+
+```
+src/<name>_mcp/
+├── repositories/
+│   ├── base.py                # AbstractRepository[CreateT, UpdateT, ReadT] ABC
+│   ├── <entity>.py            # concrete (asyncpg 직접 사용)
+│   └── __init__.py
+├── db.py                      # pool lifespan + migration runner
+└── ... (위 §1)
+
+migrations/                    # yoyo-migrations 패턴
+├── 001_<name>.sql             # forward
+└── 001_<name>.rollback.sql    # rollback (별 파일)
+```
+
+- **driver**: asyncpg (Postgres) / neo4j (Neo4j). ORM 도입 금지
+- **Migration**: yoyo, MCP 부팅 시 자동 적용 (`db.apply_migrations` in lifespan)
+- **Optimistic locking**: `version` 컬럼 + `update_with_version(expected_version=)` 메서드
+- **JSONB / 복합 타입**: repository 가 직렬화 책임 (`_to_jsonb` helper)
+
+### 2.2. API-client (IssueTracker / Wiki / 외부 SaaS)
+
+```
+src/<name>_mcp/
+├── adapters/
+│   ├── base.py                # IssueTracker / Wiki ABC (interface 계약)
+│   ├── github.py              # 구현체별 어댑터
+│   ├── jira.py                # (M5+) 추가 어댑터
+│   └── __init__.py
+├── factory.py                 # config 의 type 필드로 구현체 선택 (OCP)
+└── ... (위 §1)
+```
+
+- **driver**: httpx (REST) / 라이브러리별 SDK
+- **Migration 없음** (외부 시스템 스키마 따라감)
+- **Factory 패턴**: 새 구현체 추가 = `adapters/<name>.py` 작성 + factory 에 1줄 등록 (OCP)
+- **Schema validation**: 외부 응답을 본 모듈의 Pydantic 모델로 변환 — wire 모델이 도메인으로 새지 않게
+
+---
+
+## 3. Transport / 운영
+
+| 항목 | 값 |
+|---|---|
+| Transport | **streamable HTTP only** (stdio 사용 X — 컨테이너 토폴로지) |
+| Host binding | `0.0.0.0` (컨테이너 내부, 노출 제어는 compose port mapping) |
+| DNS rebinding 보호 | **off** (`TransportSecuritySettings(enable_dns_rebinding_protection=False)`) — 내부망 전용 |
+| 포트 대역 | **9100~9199** (root CLAUDE.md "포트 컨벤션") |
+| Endpoint path | `/mcp` (FastMCP default) |
+
+### 포트 할당 표 (현재까지)
+
+| 포트 | MCP |
+|---|---|
+| 9100 | document-db (#35) |
+| 9101 | issue-tracker (#36, M3) |
+| 9102 | wiki (#37, M3) |
+| 9103 | graph-db (M4) |
+| 9104+ | 향후 |
+
+새 MCP 추가 시 본 표 즉시 갱신.
+
+---
+
+## 4. Container 패턴
+
+```dockerfile
+# syntax=docker/dockerfile:1
+FROM python:3.13-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+COPY mcp/<name> /app/<name>
+RUN pip install -e /app/<name>
+
+WORKDIR /app/<name>
+EXPOSE 8000
+
+CMD ["python", "-m", "<name>_mcp.server"]
+```
+
+### compose 등록 (`infra/docker-compose.yml`)
+
+```yaml
+<name>-mcp:
+  profiles: ["mcp", "agents"]
+  build:
+    context: ..
+    dockerfile: mcp/<name>/Dockerfile
+  image: dev-team/<name>-mcp:latest
+  container_name: dev-team-<name>-mcp
+  restart: unless-stopped
+  environment:
+    # 본 MCP 가 필요로 하는 env (DSN / API token / 등)
+  ports:
+    - "<host_port>:8000"
+  depends_on:
+    # Postgres / Valkey / Neo4j 등 backend 의존
+```
+
+`profiles: ["mcp", "agents"]` — `--profile mcp` 만 띄울 수 있고, 에이전트 함께 띄울 때도 (`agents`) 같이 올라옴.
+
+---
+
+## 5. 새 MCP 추가 절차 (체크리스트)
+
+본 디렉터리에 새 MCP 추가 시:
+
+- [ ] **이슈 + 컨펌** — 명세 + 추상화 레이어 / 도구 면 / 배포 형태 합의
+- [ ] **포트 할당** — root CLAUDE.md "포트 컨벤션" + 본 문서 §3 표 갱신
+- [ ] **`mcp/<name>/` 디렉터리 생성** — §1.1 구조 따라
+- [ ] **`mcp/<name>/CLAUDE.md`** — 본 MCP 한정 규약 (collection 목록 / backend 디테일 / 새 entity 추가 절차 등)
+- [ ] **pyproject.toml + Dockerfile** — §4 패턴 따라
+- [ ] **`mcp_instance.py`** — FastMCP + lifespan + AppContext
+- [ ] **`schemas/` + `[repositories|adapters]/` + `tools/`** — §1 / §2 패턴
+- [ ] **`server.py`** — 얇은 entry point
+- [ ] **테스트** — schemas 단위 + repository / adapter 통합
+- [ ] **compose 등록** — `infra/docker-compose.yml`
+- [ ] **컨테이너 build / 부팅 / streamable HTTP 호출 검증**
+- [ ] **CI 파이프라인 (있을 때)** — pyproject 의존 캐시 / 테스트 실행
+
+---
+
+## 6. 절대 금지 사항 (모든 MCP 공통)
+
+- **stdio transport 사용 금지** — 컨테이너 간 통신은 streamable HTTP 만
+- **모듈 레벨 전역 자원** (DB pool / HTTP client) — lifespan + DI 만
+- **Repository / Adapter 우회 직접 driver 호출** (예: tools 에서 asyncpg 직접) — DIP 위반
+- **Schema validation 우회** — 모든 도구 입력 / 출력은 Pydantic 1회 통과
+- **인증 / 보안 미적용 시 호스트 외부 노출** — 내부망 전용. 외부 노출 필요 시 별 reverse proxy + auth
+- **`langgraph` DB 직접 접근** — Document DB MCP 만 `dev_team` DB 의 owner. 다른 MCP 가 같은 DB 를 만지지 않음 (소유권 원칙)
+
+---
+
+## 7. 관련 문서
+
+- 본 root: [`/CLAUDE.md`](../CLAUDE.md) — 프로젝트 일반 규약 (모듈 코드 구조 / 포트 컨벤션 / resources 패턴 등)
+- Reference 구현: [`mcp/document-db/`](./document-db/) — 본 문서의 패턴 1호
+- Module guide 예시: [`mcp/document-db/CLAUDE.md`](./document-db/CLAUDE.md)
+- 디자인 보고서 (#35): `/tmp/m3-35-design-proposal.md` — 본 패턴 결정 과정

--- a/mcp/document-db/CLAUDE.md
+++ b/mcp/document-db/CLAUDE.md
@@ -1,0 +1,140 @@
+# Document DB MCP — AI 에이전트 작업 규칙
+
+본 모듈을 수정하는 AI 에이전트 (Claude / 기타) 가 따라야 할 규약. root `CLAUDE.md`
+의 일반 규약 (SOLID / 모듈 코드 구조 / 포트 컨벤션 등) 위에 본 모듈 한정 사항.
+
+---
+
+## 1. 본 모듈의 역할
+
+PostgreSQL `dev_team` DB 의 thin CRUD 래퍼. **비즈니스 로직 없음** — 들어온 그대로 저장 / 꺼내 줌.
+
+| 항목 | 값 |
+|---|---|
+| Transport | streamable HTTP (MCP spec 2025-06-18) |
+| 호스트 포트 | **9100** |
+| 컨테이너 포트 | 8000 (uvicorn) |
+| DB | Postgres 단일 인스턴스의 `dev_team` DB (langgraph DB 와 분리) |
+| Migration | yoyo-migrations, MCP 부팅 시 자동 적용 |
+
+---
+
+## 2. Collection 5종 — 절대 추가 / 변경은 별 이슈
+
+| Collection | 정체성 |
+|---|---|
+| `agent_tasks` | 작업 단위 (Chronicler "Task") |
+| `agent_sessions` | 한 task 안의 대화 흐름 |
+| `agent_items` | 한 session 안의 개별 메시지 |
+| `issues` | 외부 이슈 트래커 mirror (Epic/Story/Task type) |
+| `wiki_pages` | 위키 문서 mirror (PRD/ADR/business_rule 등 type) |
+
+**원칙**:
+- 새 collection 추가 = **별 이슈 + 사용자 컨펌** 후. 즉흥 추가 금지.
+- 기존 collection 의 컬럼 변경 = **마이그레이션 신규 파일 작성** (기존 SQL 수정 X).
+- PRD 는 별 entity 안 만든다. `wiki_pages.page_type='prd'` 로 통합.
+
+---
+
+## 3. 새 collection 추가 시 절차 (OCP)
+
+```
+1. mcp/document-db/migrations/NNN_<name>.sql        새 마이그레이션 (롤백 SQL 포함)
+2. src/document_db_mcp/schemas/<name>.py            Pydantic 모델 (Create / Update / Read)
+3. src/document_db_mcp/repositories/<name>.py       AbstractRepository 상속 + 특수 쿼리
+4. src/document_db_mcp/tools/<name>.py              MCP tool 함수 (5 op generic + 특수 도구)
+5. src/document_db_mcp/tools/__init__.py            register 1줄 추가
+```
+
+**기존 파일 수정 0줄** 이 OCP 충족 시그널. 수정이 필요해진다면 abstraction 부족 → 다시 검토.
+
+---
+
+## 4. 노출 도구 면 — collection 별 5 op
+
+각 collection 이 동일한 5 op 를 노출. generic 구현 (`tools/_generic.py`) 위에 collection 별 모듈이 등록.
+
+| 도구 | 시그니처 | 비고 |
+|---|---|---|
+| `{collection}.upsert` | `(doc) → DocRef` | id 있으면 update, 없으면 insert. version 컬럼 있으면 optimistic locking |
+| `{collection}.get` | `(id) → Doc \| null` | 단건 |
+| `{collection}.list` | `(filter, limit, offset, order_by) → list[Doc]` | filter 는 jsonb path 쿼리 가능 |
+| `{collection}.delete` | `(id) → bool` | hard delete |
+| `{collection}.count` | `(filter) → int` | 페이지네이션용 |
+
+특수 도구 (Chronicler 의 read 패턴 전용):
+- `agent_items.list_by_session(session_id) → ordered list` (prev_item_id 체인)
+- `agent_sessions.list_by_task(agent_task_id) → list`
+- `agent_sessions.find_by_context(context_id) → Session | null`
+
+---
+
+## 5. Repository 패턴 — 절대 우회 금지
+
+```python
+# tools/<name>.py — 옳음
+async def upsert(repo: IssueRepository, doc: IssueCreate) -> IssueRef:
+    return await repo.upsert(doc)
+
+# tools/<name>.py — 금지 (DIP 위반)
+async def upsert_bad(pool: asyncpg.Pool, doc: IssueCreate) -> IssueRef:
+    async with pool.acquire() as conn:
+        await conn.execute("INSERT INTO issues ...")  # ← repository 우회
+```
+
+- `tools/` 코드는 `repositories/` 만 의존. asyncpg 직접 호출 금지.
+- repository 가 schema 검증 / SQL 조립 / 트랜잭션 책임 독점.
+- 새 쿼리 패턴이 필요하면 repository 에 메서드 추가 (tools 에 SQL 흩뿌리기 X).
+
+---
+
+## 6. Migration 규약 (yoyo)
+
+- 파일명: `NNN_short_name.sql` (NNN 은 0-padding 3자리, e.g. `001_chronicler.sql`)
+- 각 파일은 **반드시** `-- step:` 으로 forward / rollback 분리
+- 적용 순서는 NNN 사전순 — 번호 충돌 금지
+- 적용 시점: MCP 서버 부팅 직후 (server.py lifespan) 자동 실행
+- **기존 파일 수정 금지** — 수정 사항은 새 마이그레이션으로
+
+```sql
+-- step: 001_chronicler
+CREATE TABLE agent_tasks (...);
+
+-- step: 001_chronicler.rollback
+DROP TABLE agent_tasks;
+```
+
+---
+
+## 7. 테스트 규약
+
+- Repository 단위 = `pytest-asyncio` + `testcontainers[postgres]` 로 실 Postgres
+- Tool 단위 = Repository mock
+- 통합 = `docker compose up` 후 streamable HTTP 호출 (수동 또는 e2e 스크립트)
+
+테스트 위치:
+```
+mcp/document-db/tests/
+├── test_repositories/    # 실 Postgres
+├── test_tools/           # mock repository
+└── test_migrations/      # SQL 적용 / 롤백 검증
+```
+
+---
+
+## 8. 절대 금지 사항
+
+- **ORM 도입** (SQLAlchemy / Tortoise 등). asyncpg + raw SQL 만.
+- **repository 우회 직접 SQL**.
+- **schema validation 우회** (raw dict 외부 노출).
+- **모듈 레벨 전역 connection / pool**. lifespan + DI 만.
+- **postgres-init 에 본 모듈의 schema 작성**. schema 는 본 모듈의 마이그레이션이 담당.
+- **`langgraph` DB 직접 접근**. `dev_team` DB 만.
+
+---
+
+## 9. 관련 문서
+
+- 본 root: [`/CLAUDE.md`](../../CLAUDE.md) — 프로젝트 일반 규약
+- 스키마 본문: [`docs/document-db-schema.md`](../../docs/document-db-schema.md)
+- 이슈 #35 의 design proposal — 본 모듈 첫 commit 의 근거

--- a/mcp/document-db/Dockerfile
+++ b/mcp/document-db/Dockerfile
@@ -1,0 +1,35 @@
+# syntax=docker/dockerfile:1
+#
+# Document DB MCP 서버 이미지.
+#
+# 베이스: python:3.13-slim
+# 런타임: FastMCP (mcp SDK) 위 streamable HTTP transport (uvicorn).
+# DB: 단일 Postgres 인스턴스의 dev_team DB (langgraph DB 와 분리, 이슈 #20).
+#
+# 빌드 (레포 루트에서):
+#   docker build -f mcp/document-db/Dockerfile -t dev-team/document-db-mcp:latest .
+#
+# 런타임 변수:
+#   DATABASE_URI         dev_team DB DSN (compose 가 주입)
+#   AUTO_MIGRATE         true (기본). 부팅 시 yoyo 마이그레이션 자동 적용
+
+FROM python:3.13-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+COPY mcp/document-db /app/document-db
+RUN pip install -e /app/document-db
+
+WORKDIR /app/document-db
+EXPOSE 8000
+
+CMD ["python", "-m", "document_db_mcp.server"]

--- a/mcp/document-db/migrations/001_chronicler.rollback.sql
+++ b/mcp/document-db/migrations/001_chronicler.rollback.sql
@@ -1,0 +1,4 @@
+-- 001_chronicler — rollback
+DROP TABLE IF EXISTS agent_items CASCADE;
+DROP TABLE IF EXISTS agent_sessions CASCADE;
+DROP TABLE IF EXISTS agent_tasks CASCADE;

--- a/mcp/document-db/migrations/001_chronicler.sql
+++ b/mcp/document-db/migrations/001_chronicler.sql
@@ -1,0 +1,51 @@
+-- 001_chronicler.sql — forward
+-- Chronicler 의 3계층 (Task / Session / Item) + UUID 지원
+-- 참조: docs/document-db-schema.md §1, §2, §3
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE agent_tasks (
+    id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    title         TEXT NOT NULL,
+    description   TEXT,
+    status        TEXT NOT NULL DEFAULT 'open'
+                  CHECK (status IN ('open', 'in_progress', 'done', 'cancelled')),
+    owner_agent   TEXT,
+    issue_refs    UUID[] NOT NULL DEFAULT '{}',
+    metadata      JSONB NOT NULL DEFAULT '{}',
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX idx_agent_tasks_status ON agent_tasks (status);
+CREATE INDEX idx_agent_tasks_owner  ON agent_tasks (owner_agent);
+CREATE INDEX idx_agent_tasks_issues ON agent_tasks USING GIN (issue_refs);
+
+CREATE TABLE agent_sessions (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    agent_task_id   UUID NOT NULL REFERENCES agent_tasks(id) ON DELETE CASCADE,
+    initiator       TEXT NOT NULL,
+    counterpart     TEXT NOT NULL,
+    context_id      TEXT NOT NULL,
+    trace_id        TEXT,
+    topic           TEXT,
+    metadata        JSONB NOT NULL DEFAULT '{}',
+    started_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    ended_at        TIMESTAMPTZ
+);
+CREATE INDEX idx_agent_sessions_task    ON agent_sessions (agent_task_id, started_at);
+CREATE INDEX idx_agent_sessions_context ON agent_sessions (context_id);
+CREATE INDEX idx_agent_sessions_trace   ON agent_sessions (trace_id);
+
+CREATE TABLE agent_items (
+    id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    agent_session_id  UUID NOT NULL REFERENCES agent_sessions(id) ON DELETE CASCADE,
+    prev_item_id      UUID REFERENCES agent_items(id),
+    role              TEXT NOT NULL CHECK (role IN ('user', 'agent', 'system')),
+    sender            TEXT NOT NULL,
+    content           JSONB NOT NULL,
+    message_id        TEXT,
+    metadata          JSONB NOT NULL DEFAULT '{}',
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX idx_agent_items_session ON agent_items (agent_session_id, created_at);
+CREATE INDEX idx_agent_items_prev    ON agent_items (prev_item_id);

--- a/mcp/document-db/migrations/002_issues.rollback.sql
+++ b/mcp/document-db/migrations/002_issues.rollback.sql
@@ -1,0 +1,2 @@
+-- 002_issues — rollback
+DROP TABLE IF EXISTS issues CASCADE;

--- a/mcp/document-db/migrations/002_issues.sql
+++ b/mcp/document-db/migrations/002_issues.sql
@@ -1,0 +1,26 @@
+-- 002_issues.sql — forward
+-- 외부 이슈 트래커 mirror (Epic / Story / Task type)
+-- 참조: docs/document-db-schema.md §4
+
+CREATE TABLE issues (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    agent_task_id   UUID REFERENCES agent_tasks(id) ON DELETE SET NULL,
+    type            TEXT NOT NULL CHECK (type IN ('epic', 'story', 'task')),
+    title           TEXT NOT NULL,
+    body_md         TEXT NOT NULL,
+    status          TEXT NOT NULL DEFAULT 'draft'
+                    CHECK (status IN ('draft', 'confirmed', 'cancelled')),
+    parent_issue_id UUID REFERENCES issues(id) ON DELETE SET NULL,
+    labels          TEXT[] NOT NULL DEFAULT '{}',
+    external_refs   JSONB NOT NULL DEFAULT '{}',
+    last_synced_at  TIMESTAMPTZ,
+    metadata        JSONB NOT NULL DEFAULT '{}',
+    version         INT NOT NULL DEFAULT 1,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX idx_issues_task        ON issues (agent_task_id);
+CREATE INDEX idx_issues_type_status ON issues (type, status);
+CREATE INDEX idx_issues_parent      ON issues (parent_issue_id);
+CREATE INDEX idx_issues_external    ON issues USING GIN (external_refs);
+CREATE INDEX idx_issues_labels      ON issues USING GIN (labels);

--- a/mcp/document-db/migrations/003_wiki_pages.rollback.sql
+++ b/mcp/document-db/migrations/003_wiki_pages.rollback.sql
@@ -1,0 +1,2 @@
+-- 003_wiki_pages — rollback
+DROP TABLE IF EXISTS wiki_pages CASCADE;

--- a/mcp/document-db/migrations/003_wiki_pages.sql
+++ b/mcp/document-db/migrations/003_wiki_pages.sql
@@ -1,0 +1,34 @@
+-- 003_wiki_pages.sql — forward
+-- 위키 문서 mirror (PRD / ADR / business_rule 등 page_type 별 통합)
+-- 참조: docs/document-db-schema.md §5
+
+CREATE TABLE wiki_pages (
+    id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    agent_task_id       UUID REFERENCES agent_tasks(id) ON DELETE SET NULL,
+    page_type           TEXT NOT NULL
+                        CHECK (page_type IN (
+                            'prd', 'business_rule', 'data_model',
+                            'adr', 'api_contract',
+                            'glossary', 'runbook', 'generic'
+                        )),
+    slug                TEXT NOT NULL UNIQUE,
+    title               TEXT NOT NULL,
+    content_md          TEXT NOT NULL,
+    status              TEXT NOT NULL DEFAULT 'draft'
+                        CHECK (status IN ('draft', 'confirmed', 'cancelled')),
+    author_agent        TEXT,
+    references_issues   UUID[] NOT NULL DEFAULT '{}',
+    references_pages    UUID[] NOT NULL DEFAULT '{}',
+    structured          JSONB NOT NULL DEFAULT '{}',
+    external_refs       JSONB NOT NULL DEFAULT '{}',
+    last_synced_at      TIMESTAMPTZ,
+    metadata            JSONB NOT NULL DEFAULT '{}',
+    version             INT NOT NULL DEFAULT 1,
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX idx_wiki_pages_type_status ON wiki_pages (page_type, status);
+CREATE INDEX idx_wiki_pages_task        ON wiki_pages (agent_task_id);
+CREATE INDEX idx_wiki_pages_external    ON wiki_pages USING GIN (external_refs);
+CREATE INDEX idx_wiki_pages_refs_issues ON wiki_pages USING GIN (references_issues);
+CREATE INDEX idx_wiki_pages_refs_pages  ON wiki_pages USING GIN (references_pages);

--- a/mcp/document-db/pyproject.toml
+++ b/mcp/document-db/pyproject.toml
@@ -1,0 +1,44 @@
+[project]
+name = "document-db-mcp"
+version = "0.1.0"
+description = "Document DB MCP — PostgreSQL JSONB CRUD over streamable HTTP for dev-team agents"
+requires-python = ">=3.13,<3.14"
+
+# 모든 하한은 PyPI 최신 stable (2026-05 시점) 기준
+dependencies = [
+  # MCP SDK — streamable HTTP transport (spec 2025-06-18)
+  "mcp>=1.27.0",
+  # PostgreSQL async driver (ORM 도입 금지 — root CLAUDE.md / mcp/document-db/CLAUDE.md §8)
+  "asyncpg>=0.31.0",
+  # Schema validation
+  "pydantic>=2.13.3",
+  # env / config
+  "pydantic-settings>=2.14.0",
+  # Migration (CLAUDE.md §6)
+  "yoyo-migrations>=9.0.0",
+  # yoyo 의 sync driver — psycopg3 (langgraph 와 동일 driver)
+  "psycopg[binary]>=3.2.0",
+  # ASGI server (streamable HTTP 위에 올리기 위함)
+  "uvicorn[standard]>=0.32.0",
+  # FastAPI (MCP 의 streamable HTTP app 마운트용)
+  "fastapi>=0.120.0",
+]
+
+[project.optional-dependencies]
+dev = [
+  "pytest>=9.0.3",
+  "pytest-asyncio>=1.3.0",
+  "testcontainers[postgres]>=4.14.2",
+  "httpx>=0.28.0",
+]
+
+[build-system]
+requires = ["setuptools>=70"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]

--- a/mcp/document-db/src/document_db_mcp/__init__.py
+++ b/mcp/document-db/src/document_db_mcp/__init__.py
@@ -1,0 +1,9 @@
+"""Document DB MCP — PostgreSQL JSONB CRUD over streamable HTTP.
+
+`dev_team` DB 의 5 collections (agent_tasks / agent_sessions / agent_items /
+issues / wiki_pages) 에 대한 thin CRUD 래퍼. 비즈니스 로직 없음.
+
+자세한 규약은 모듈 루트의 `CLAUDE.md` 참조.
+"""
+
+__version__ = "0.1.0"

--- a/mcp/document-db/src/document_db_mcp/config.py
+++ b/mcp/document-db/src/document_db_mcp/config.py
@@ -1,0 +1,34 @@
+"""env 기반 설정. lifespan 에서 1회 로드 후 주입."""
+
+from __future__ import annotations
+
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    """Document DB MCP 서버 설정.
+
+    env 우선순위 (Pydantic Settings 표준): env var > .env > 기본값.
+    """
+
+    model_config = SettingsConfigDict(env_file=".env", extra="ignore")
+
+    # Postgres dev_team DB 의 DSN. compose 가 주입.
+    database_uri: str = Field(
+        default="postgres://devteam:devteam_postgres@localhost:5432/dev_team",
+        description="dev_team DB 연결 DSN (langgraph DB 와 분리, 이슈 #20)",
+    )
+
+    # asyncpg pool 설정
+    pool_min_size: int = 2
+    pool_max_size: int = 10
+
+    # streamable HTTP 서버 포트 (컨테이너 내부)
+    http_port: int = 8000
+
+    # Migration 자동 적용 여부 (테스트 시 끌 수 있게)
+    auto_migrate: bool = True
+
+
+__all__ = ["Settings"]

--- a/mcp/document-db/src/document_db_mcp/db.py
+++ b/mcp/document-db/src/document_db_mcp/db.py
@@ -1,0 +1,64 @@
+"""DB 연결 + 마이그레이션 적용.
+
+asyncpg pool 생성 / cleanup, yoyo 기반 마이그레이션 자동 적용.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import asyncpg
+from yoyo import get_backend, read_migrations
+
+logger = logging.getLogger(__name__)
+
+# 본 모듈 위치 기준 migrations 디렉터리 경로
+_MIGRATIONS_DIR = Path(__file__).resolve().parents[2] / "migrations"
+
+
+def apply_migrations(database_uri: str) -> None:
+    """yoyo-migrations 로 마이그레이션 자동 적용.
+
+    yoyo 는 sync API 라 asyncio 컨텍스트 밖에서 호출 (lifespan 에서 to_thread).
+    `_yoyo_migration` 테이블로 적용 상태 추적, idempotent.
+    """
+    # yoyo 는 postgresql+psycopg:// 스키마로 psycopg3 driver 사용 (langgraph 와 동일)
+    yoyo_uri = database_uri.replace("postgres://", "postgresql+psycopg://", 1)
+    if not yoyo_uri.startswith("postgresql+psycopg://"):
+        # 이미 postgresql:// 면 그대로 두지 않고 psycopg3 로
+        yoyo_uri = yoyo_uri.replace("postgresql://", "postgresql+psycopg://", 1)
+    backend = get_backend(yoyo_uri)
+    migrations = read_migrations(str(_MIGRATIONS_DIR))
+    with backend.lock():
+        backend.apply_migrations(backend.to_apply(migrations))
+    logger.info("migrations applied (dir=%s)", _MIGRATIONS_DIR)
+
+
+@asynccontextmanager
+async def pool_lifespan(
+    database_uri: str,
+    *,
+    min_size: int = 2,
+    max_size: int = 10,
+) -> AsyncIterator[asyncpg.Pool]:
+    """asyncpg Pool 생성 / 정리 컨텍스트.
+
+    server.py lifespan 에서 사용 — DI 진입점.
+    """
+    pool = await asyncpg.create_pool(
+        dsn=database_uri,
+        min_size=min_size,
+        max_size=max_size,
+    )
+    try:
+        logger.info("asyncpg pool ready (min=%d, max=%d)", min_size, max_size)
+        yield pool
+    finally:
+        await pool.close()
+        logger.info("asyncpg pool closed")
+
+
+__all__ = ["apply_migrations", "pool_lifespan"]

--- a/mcp/document-db/src/document_db_mcp/mcp_instance.py
+++ b/mcp/document-db/src/document_db_mcp/mcp_instance.py
@@ -1,0 +1,85 @@
+"""FastMCP 싱글턴 + lifespan.
+
+본 모듈이 `mcp` 인스턴스를 노출. tools/ 의 각 모듈이 본 인스턴스를 import 해
+`@mcp.tool()` 으로 도구 등록. lifespan 은 Repository 들을 만들어 AppContext 로
+yield → 도구는 `ctx.request_context.lifespan_context.X` 로 접근.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+
+from mcp.server.fastmcp import FastMCP
+from mcp.server.transport_security import TransportSecuritySettings
+
+from document_db_mcp.config import Settings
+from document_db_mcp.db import apply_migrations, pool_lifespan
+from document_db_mcp.repositories import (
+    AgentItemRepository,
+    AgentSessionRepository,
+    AgentTaskRepository,
+    IssueRepository,
+    WikiPageRepository,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class AppContext:
+    """lifespan 이 yield 하는 의존성 묶음. 도구는 본 객체로부터 repository 를 꺼내 씀."""
+
+    agent_task: AgentTaskRepository
+    agent_session: AgentSessionRepository
+    agent_item: AgentItemRepository
+    issue: IssueRepository
+    wiki_page: WikiPageRepository
+
+
+@asynccontextmanager
+async def _app_lifespan(_server: FastMCP) -> AsyncIterator[AppContext]:
+    settings = Settings()
+
+    if settings.auto_migrate:
+        logger.info("applying migrations…")
+        await asyncio.to_thread(apply_migrations, settings.database_uri)
+
+    async with pool_lifespan(
+        settings.database_uri,
+        min_size=settings.pool_min_size,
+        max_size=settings.pool_max_size,
+    ) as pool:
+        ctx = AppContext(
+            agent_task=AgentTaskRepository(pool),
+            agent_session=AgentSessionRepository(pool),
+            agent_item=AgentItemRepository(pool),
+            issue=IssueRepository(pool),
+            wiki_page=WikiPageRepository(pool),
+        )
+        logger.info("document-db-mcp ready (5 collections)")
+        yield ctx
+
+
+# 모듈 레벨 인스턴스 — tools/ 가 import 해서 데코레이터 등록.
+# 자원 자체는 lifespan_context 안에 있고, 본 인스턴스는 등록 라우터 역할만.
+#
+# host="0.0.0.0": 컨테이너 외부 (다른 컨테이너 / 호스트) 에서 접근 허용.
+# DNS rebinding 보호는 우리 토폴로지 (내부망 전용) 에서 불필요 → 끄지 않으면
+# docker network 의 다른 호스트명에서 차단됨.
+_settings_boot = Settings()
+mcp = FastMCP(
+    "document-db",
+    lifespan=_app_lifespan,
+    host="0.0.0.0",  # noqa: S104 — 컨테이너 내부 binding, 노출 제어는 compose port mapping 으로
+    port=_settings_boot.http_port,
+    transport_security=TransportSecuritySettings(
+        enable_dns_rebinding_protection=False,
+    ),
+)
+
+
+__all__ = ["AppContext", "mcp"]

--- a/mcp/document-db/src/document_db_mcp/repositories/__init__.py
+++ b/mcp/document-db/src/document_db_mcp/repositories/__init__.py
@@ -1,0 +1,18 @@
+"""Repository 레이어 — collection 별 CRUD 구현."""
+
+from document_db_mcp.repositories.agent_item import AgentItemRepository
+from document_db_mcp.repositories.agent_session import AgentSessionRepository
+from document_db_mcp.repositories.agent_task import AgentTaskRepository
+from document_db_mcp.repositories.base import AbstractRepository, ListFilter
+from document_db_mcp.repositories.issue import IssueRepository
+from document_db_mcp.repositories.wiki_page import WikiPageRepository
+
+__all__ = [
+    "AbstractRepository",
+    "AgentItemRepository",
+    "AgentSessionRepository",
+    "AgentTaskRepository",
+    "IssueRepository",
+    "ListFilter",
+    "WikiPageRepository",
+]

--- a/mcp/document-db/src/document_db_mcp/repositories/agent_item.py
+++ b/mcp/document-db/src/document_db_mcp/repositories/agent_item.py
@@ -1,0 +1,77 @@
+"""AgentItemRepository — items 는 immutable. update 는 의도적으로 미지원."""
+
+from __future__ import annotations
+
+import json
+from typing import NoReturn
+from uuid import UUID
+
+import asyncpg
+
+from document_db_mcp.repositories.base import AbstractRepository
+from document_db_mcp.schemas.agent_item import AgentItemCreate, AgentItemRead
+
+
+class _ImmutableUpdate:  # placeholder type for ABC contract
+    pass
+
+
+class AgentItemRepository(
+    AbstractRepository[AgentItemCreate, _ImmutableUpdate, AgentItemRead],
+):
+    """대화 메시지 1건. 한 번 쓰면 변경 X (audit / Chronicler 의 영속성).
+
+    update 는 ABC 계약상 시그니처는 있으나 호출 시 RuntimeError. tools 는 노출하지 않음.
+    """
+
+    @property
+    def table_name(self) -> str:
+        return "agent_items"
+
+    def _row_to_read(self, row: asyncpg.Record) -> AgentItemRead:
+        d = dict(row)
+        for col in ("content", "metadata"):
+            if isinstance(d.get(col), str):
+                d[col] = json.loads(d[col])
+        return AgentItemRead.model_validate(d)
+
+    async def create(self, doc: AgentItemCreate) -> AgentItemRead:
+        sql = """
+            INSERT INTO agent_items
+                (agent_session_id, prev_item_id, role, sender, content, message_id, metadata)
+            VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7::jsonb)
+            RETURNING *
+        """
+        row = await self._pool.fetchrow(
+            sql,
+            doc.agent_session_id,
+            doc.prev_item_id,
+            doc.role,
+            doc.sender,
+            self._to_jsonb(doc.content),
+            doc.message_id,
+            self._to_jsonb(doc.metadata),
+        )
+        assert row is not None
+        return self._row_to_read(row)
+
+    async def update(self, id: UUID, patch: _ImmutableUpdate) -> NoReturn:  # type: ignore[override]
+        raise RuntimeError(
+            "agent_items are immutable; update is not supported by design",
+        )
+
+    # ---- 특수 쿼리 ----
+
+    async def list_by_session(self, agent_session_id: UUID) -> list[AgentItemRead]:
+        """session 안의 모든 item 을 created_at 순으로 반환.
+
+        prev_item_id chain 도 결국 created_at 순과 일치 (단조 증가) 라 단순 정렬로 충분.
+        """
+        rows = await self._pool.fetch(
+            "SELECT * FROM agent_items WHERE agent_session_id = $1 ORDER BY created_at",
+            agent_session_id,
+        )
+        return [self._row_to_read(r) for r in rows]
+
+
+__all__ = ["AgentItemRepository"]

--- a/mcp/document-db/src/document_db_mcp/repositories/agent_session.py
+++ b/mcp/document-db/src/document_db_mcp/repositories/agent_session.py
@@ -1,0 +1,91 @@
+"""AgentSessionRepository."""
+
+from __future__ import annotations
+
+import json
+from uuid import UUID
+
+import asyncpg
+
+from document_db_mcp.repositories.base import AbstractRepository
+from document_db_mcp.schemas.agent_session import (
+    AgentSessionCreate,
+    AgentSessionRead,
+    AgentSessionUpdate,
+)
+
+
+class AgentSessionRepository(
+    AbstractRepository[AgentSessionCreate, AgentSessionUpdate, AgentSessionRead],
+):
+    @property
+    def table_name(self) -> str:
+        return "agent_sessions"
+
+    def _row_to_read(self, row: asyncpg.Record) -> AgentSessionRead:
+        d = dict(row)
+        if isinstance(d.get("metadata"), str):
+            d["metadata"] = json.loads(d["metadata"])
+        return AgentSessionRead.model_validate(d)
+
+    async def create(self, doc: AgentSessionCreate) -> AgentSessionRead:
+        sql = """
+            INSERT INTO agent_sessions
+                (agent_task_id, initiator, counterpart, context_id, trace_id, topic, metadata)
+            VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb)
+            RETURNING *
+        """
+        row = await self._pool.fetchrow(
+            sql,
+            doc.agent_task_id,
+            doc.initiator,
+            doc.counterpart,
+            doc.context_id,
+            doc.trace_id,
+            doc.topic,
+            self._to_jsonb(doc.metadata),
+        )
+        assert row is not None
+        return self._row_to_read(row)
+
+    async def update(self, id: UUID, patch: AgentSessionUpdate) -> AgentSessionRead | None:
+        fields = patch.model_dump(exclude_unset=True)
+        if not fields:
+            return await self.get(id)
+        set_clauses: list[str] = []
+        params: list[object] = []
+        for i, (col, val) in enumerate(fields.items(), start=1):
+            if col == "metadata":
+                set_clauses.append(f"{col} = ${i}::jsonb")
+                params.append(self._to_jsonb(val))
+            else:
+                set_clauses.append(f"{col} = ${i}")
+                params.append(val)
+        sql = (
+            f"UPDATE agent_sessions SET {', '.join(set_clauses)} "
+            f"WHERE id = ${len(params) + 1} RETURNING *"
+        )
+        params.append(id)
+        row = await self._pool.fetchrow(sql, *params)
+        return self._row_to_read(row) if row else None
+
+    # ---- 특수 쿼리 ----
+
+    async def list_by_task(self, agent_task_id: UUID) -> list[AgentSessionRead]:
+        rows = await self._pool.fetch(
+            "SELECT * FROM agent_sessions WHERE agent_task_id = $1 ORDER BY started_at",
+            agent_task_id,
+        )
+        return [self._row_to_read(r) for r in rows]
+
+    async def find_by_context(self, context_id: str) -> AgentSessionRead | None:
+        """가장 최근 session 1건 (같은 contextId 가 여러 turn 에 걸칠 수 있음)."""
+        row = await self._pool.fetchrow(
+            "SELECT * FROM agent_sessions WHERE context_id = $1 "
+            "ORDER BY started_at DESC LIMIT 1",
+            context_id,
+        )
+        return self._row_to_read(row) if row else None
+
+
+__all__ = ["AgentSessionRepository"]

--- a/mcp/document-db/src/document_db_mcp/repositories/agent_task.py
+++ b/mcp/document-db/src/document_db_mcp/repositories/agent_task.py
@@ -1,0 +1,74 @@
+"""AgentTaskRepository — agent_tasks CRUD."""
+
+from __future__ import annotations
+
+import json
+from uuid import UUID
+
+import asyncpg
+
+from document_db_mcp.repositories.base import AbstractRepository
+from document_db_mcp.schemas.agent_task import (
+    AgentTaskCreate,
+    AgentTaskRead,
+    AgentTaskUpdate,
+)
+
+
+class AgentTaskRepository(
+    AbstractRepository[AgentTaskCreate, AgentTaskUpdate, AgentTaskRead],
+):
+    @property
+    def table_name(self) -> str:
+        return "agent_tasks"
+
+    def _row_to_read(self, row: asyncpg.Record) -> AgentTaskRead:
+        d = dict(row)
+        # asyncpg 가 jsonb 를 str 로 반환하는 경우 (driver 버전 / type codec 미설정)
+        if isinstance(d.get("metadata"), str):
+            d["metadata"] = json.loads(d["metadata"])
+        return AgentTaskRead.model_validate(d)
+
+    async def create(self, doc: AgentTaskCreate) -> AgentTaskRead:
+        sql = """
+            INSERT INTO agent_tasks (title, description, status, owner_agent, issue_refs, metadata)
+            VALUES ($1, $2, $3, $4, $5, $6::jsonb)
+            RETURNING *
+        """
+        row = await self._pool.fetchrow(
+            sql,
+            doc.title,
+            doc.description,
+            doc.status,
+            doc.owner_agent,
+            doc.issue_refs,
+            self._to_jsonb(doc.metadata),
+        )
+        assert row is not None
+        return self._row_to_read(row)
+
+    async def update(self, id: UUID, patch: AgentTaskUpdate) -> AgentTaskRead | None:
+        # 명시된 필드만 patch
+        fields = patch.model_dump(exclude_unset=True)
+        if not fields:
+            return await self.get(id)
+        set_clauses: list[str] = []
+        params: list[object] = []
+        for i, (col, val) in enumerate(fields.items(), start=1):
+            if col == "metadata":
+                set_clauses.append(f"{col} = ${i}::jsonb")
+                params.append(self._to_jsonb(val))
+            else:
+                set_clauses.append(f"{col} = ${i}")
+                params.append(val)
+        set_clauses.append("updated_at = NOW()")
+        sql = (
+            f"UPDATE agent_tasks SET {', '.join(set_clauses)} "
+            f"WHERE id = ${len(params) + 1} RETURNING *"
+        )
+        params.append(id)
+        row = await self._pool.fetchrow(sql, *params)
+        return self._row_to_read(row) if row else None
+
+
+__all__ = ["AgentTaskRepository"]

--- a/mcp/document-db/src/document_db_mcp/repositories/base.py
+++ b/mcp/document-db/src/document_db_mcp/repositories/base.py
@@ -1,0 +1,108 @@
+"""AbstractRepository — collection 별 CRUD 의 공통 계약 (DIP / OCP).
+
+새 collection 추가 시 본 ABC 를 상속해 concrete 작성. tools 는 ABC 만 의존.
+"""
+
+from __future__ import annotations
+
+import json
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any, Generic, TypeVar
+from uuid import UUID
+
+import asyncpg
+from pydantic import BaseModel
+
+CreateT = TypeVar("CreateT", bound=BaseModel)
+UpdateT = TypeVar("UpdateT", bound=BaseModel)
+ReadT = TypeVar("ReadT", bound=BaseModel)
+
+
+@dataclass(frozen=True)
+class ListFilter:
+    """list 조회 시 사용. 단순 equality 매칭만 (복잡 쿼리는 collection 별 메서드)."""
+
+    where: dict[str, Any] | None = None  # column → value
+    limit: int = 100
+    offset: int = 0
+    order_by: str = "created_at DESC"
+
+
+class AbstractRepository(ABC, Generic[CreateT, UpdateT, ReadT]):
+    """5 op generic CRUD. concrete 가 table 이름 / row → model 변환만 채우면 됨.
+
+    `version` 컬럼이 있는 collection (issues / wiki_pages) 의 optimistic locking 은
+    concrete 에서 update / upsert override 로 처리.
+    """
+
+    def __init__(self, pool: asyncpg.Pool) -> None:
+        self._pool = pool
+
+    @property
+    @abstractmethod
+    def table_name(self) -> str:
+        """대상 테이블명. e.g. 'agent_tasks'."""
+
+    @abstractmethod
+    def _row_to_read(self, row: asyncpg.Record) -> ReadT:
+        """DB row → ReadT 변환. JSONB / array 직렬화 처리는 여기서."""
+
+    @abstractmethod
+    async def create(self, doc: CreateT) -> ReadT:
+        """insert. concrete 가 컬럼 목록 / VALUES 작성 책임."""
+
+    @abstractmethod
+    async def update(self, id: UUID, patch: UpdateT) -> ReadT | None:
+        """patch update. None 반환 = id 미존재."""
+
+    # ----- 공통 구현 (concrete 가 override 필요 없음) -----
+
+    async def get(self, id: UUID) -> ReadT | None:
+        sql = f"SELECT * FROM {self.table_name} WHERE id = $1"  # noqa: S608 — table_name 은 abstract property, 외부 입력 X
+        row = await self._pool.fetchrow(sql, id)
+        return self._row_to_read(row) if row else None
+
+    async def delete(self, id: UUID) -> bool:
+        sql = f"DELETE FROM {self.table_name} WHERE id = $1"  # noqa: S608
+        result = await self._pool.execute(sql, id)
+        # asyncpg execute returns 'DELETE N' string
+        return result.endswith(" 1")
+
+    async def list(self, flt: ListFilter | None = None) -> list[ReadT]:
+        flt = flt or ListFilter()
+        where_sql, params = self._where_clause(flt.where or {})
+        # order_by / limit / offset 은 caller-controlled (관리자 사용) 이지만
+        # tools 레이어가 화이트리스트 검증해서 SQL 인젝션 방어해야 함.
+        sql = (
+            f"SELECT * FROM {self.table_name} {where_sql} "  # noqa: S608
+            f"ORDER BY {flt.order_by} "
+            f"LIMIT ${len(params) + 1} OFFSET ${len(params) + 2}"
+        )
+        rows = await self._pool.fetch(sql, *params, flt.limit, flt.offset)
+        return [self._row_to_read(r) for r in rows]
+
+    async def count(self, where: dict[str, Any] | None = None) -> int:
+        where_sql, params = self._where_clause(where or {})
+        sql = f"SELECT COUNT(*) FROM {self.table_name} {where_sql}"  # noqa: S608
+        return await self._pool.fetchval(sql, *params) or 0
+
+    @staticmethod
+    def _where_clause(where: dict[str, Any]) -> tuple[str, list[Any]]:
+        """단순 equality WHERE — 기본 op 만. 복잡 쿼리는 collection 별 메서드로."""
+        if not where:
+            return "", []
+        clauses: list[str] = []
+        params: list[Any] = []
+        for i, (col, val) in enumerate(where.items(), start=1):
+            clauses.append(f"{col} = ${i}")
+            params.append(val)
+        return "WHERE " + " AND ".join(clauses), params
+
+    @staticmethod
+    def _to_jsonb(value: Any) -> str:
+        """asyncpg 가 dict 를 JSONB 로 자동 매핑하지 않아 명시 직렬화."""
+        return json.dumps(value)
+
+
+__all__ = ["AbstractRepository", "ListFilter"]

--- a/mcp/document-db/src/document_db_mcp/repositories/issue.py
+++ b/mcp/document-db/src/document_db_mcp/repositories/issue.py
@@ -1,0 +1,110 @@
+"""IssueRepository — version 컬럼 (optimistic concurrency) 적용."""
+
+from __future__ import annotations
+
+import json
+from uuid import UUID
+
+import asyncpg
+
+from document_db_mcp.repositories.base import AbstractRepository
+from document_db_mcp.schemas.issue import IssueCreate, IssueRead, IssueUpdate
+
+
+class IssueOptimisticLockError(RuntimeError):
+    """version mismatch — concurrent update 감지 시."""
+
+
+class IssueRepository(AbstractRepository[IssueCreate, IssueUpdate, IssueRead]):
+    @property
+    def table_name(self) -> str:
+        return "issues"
+
+    def _row_to_read(self, row: asyncpg.Record) -> IssueRead:
+        d = dict(row)
+        for col in ("external_refs", "metadata"):
+            if isinstance(d.get(col), str):
+                d[col] = json.loads(d[col])
+        return IssueRead.model_validate(d)
+
+    async def create(self, doc: IssueCreate) -> IssueRead:
+        sql = """
+            INSERT INTO issues
+                (agent_task_id, type, title, body_md, status, parent_issue_id,
+                 labels, external_refs, metadata)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb, $9::jsonb)
+            RETURNING *
+        """
+        row = await self._pool.fetchrow(
+            sql,
+            doc.agent_task_id,
+            doc.type,
+            doc.title,
+            doc.body_md,
+            doc.status,
+            doc.parent_issue_id,
+            doc.labels,
+            self._to_jsonb(doc.external_refs),
+            self._to_jsonb(doc.metadata),
+        )
+        assert row is not None
+        return self._row_to_read(row)
+
+    async def update(self, id: UUID, patch: IssueUpdate) -> IssueRead | None:
+        return await self.update_with_version(id, patch, expected_version=None)
+
+    async def update_with_version(
+        self,
+        id: UUID,
+        patch: IssueUpdate,
+        *,
+        expected_version: int | None,
+    ) -> IssueRead | None:
+        """expected_version 지정 시 optimistic lock — mismatch 면 IssueOptimisticLockError."""
+        fields = patch.model_dump(exclude_unset=True)
+        if not fields:
+            return await self.get(id)
+        set_clauses: list[str] = []
+        params: list[object] = []
+        for i, (col, val) in enumerate(fields.items(), start=1):
+            if col in ("external_refs", "metadata"):
+                set_clauses.append(f"{col} = ${i}::jsonb")
+                params.append(self._to_jsonb(val))
+            else:
+                set_clauses.append(f"{col} = ${i}")
+                params.append(val)
+        # version + updated_at 자동 갱신
+        set_clauses.append("version = version + 1")
+        set_clauses.append("updated_at = NOW()")
+
+        if expected_version is not None:
+            sql = (
+                f"UPDATE issues SET {', '.join(set_clauses)} "
+                f"WHERE id = ${len(params) + 1} AND version = ${len(params) + 2} "
+                f"RETURNING *"
+            )
+            params.extend([id, expected_version])
+            row = await self._pool.fetchrow(sql, *params)
+            if row is None:
+                # id 자체가 없는지 / version 불일치인지 구분
+                exists = await self._pool.fetchval(
+                    "SELECT 1 FROM issues WHERE id = $1", id,
+                )
+                if exists:
+                    raise IssueOptimisticLockError(
+                        f"version mismatch on issue {id} "
+                        f"(expected={expected_version})",
+                    )
+                return None
+            return self._row_to_read(row)
+
+        sql = (
+            f"UPDATE issues SET {', '.join(set_clauses)} "
+            f"WHERE id = ${len(params) + 1} RETURNING *"
+        )
+        params.append(id)
+        row = await self._pool.fetchrow(sql, *params)
+        return self._row_to_read(row) if row else None
+
+
+__all__ = ["IssueRepository", "IssueOptimisticLockError"]

--- a/mcp/document-db/src/document_db_mcp/repositories/wiki_page.py
+++ b/mcp/document-db/src/document_db_mcp/repositories/wiki_page.py
@@ -1,0 +1,125 @@
+"""WikiPageRepository — version + slug UNIQUE."""
+
+from __future__ import annotations
+
+import json
+from uuid import UUID
+
+import asyncpg
+
+from document_db_mcp.repositories.base import AbstractRepository
+from document_db_mcp.schemas.wiki_page import (
+    WikiPageCreate,
+    WikiPageRead,
+    WikiPageUpdate,
+)
+
+
+class WikiPageOptimisticLockError(RuntimeError):
+    """version mismatch."""
+
+
+class WikiPageRepository(
+    AbstractRepository[WikiPageCreate, WikiPageUpdate, WikiPageRead],
+):
+    @property
+    def table_name(self) -> str:
+        return "wiki_pages"
+
+    def _row_to_read(self, row: asyncpg.Record) -> WikiPageRead:
+        d = dict(row)
+        for col in ("structured", "external_refs", "metadata"):
+            if isinstance(d.get(col), str):
+                d[col] = json.loads(d[col])
+        return WikiPageRead.model_validate(d)
+
+    async def create(self, doc: WikiPageCreate) -> WikiPageRead:
+        sql = """
+            INSERT INTO wiki_pages
+                (agent_task_id, page_type, slug, title, content_md, status,
+                 author_agent, references_issues, references_pages,
+                 structured, external_refs, metadata)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10::jsonb, $11::jsonb, $12::jsonb)
+            RETURNING *
+        """
+        row = await self._pool.fetchrow(
+            sql,
+            doc.agent_task_id,
+            doc.page_type,
+            doc.slug,
+            doc.title,
+            doc.content_md,
+            doc.status,
+            doc.author_agent,
+            doc.references_issues,
+            doc.references_pages,
+            self._to_jsonb(doc.structured),
+            self._to_jsonb(doc.external_refs),
+            self._to_jsonb(doc.metadata),
+        )
+        assert row is not None
+        return self._row_to_read(row)
+
+    async def update(self, id: UUID, patch: WikiPageUpdate) -> WikiPageRead | None:
+        return await self.update_with_version(id, patch, expected_version=None)
+
+    async def update_with_version(
+        self,
+        id: UUID,
+        patch: WikiPageUpdate,
+        *,
+        expected_version: int | None,
+    ) -> WikiPageRead | None:
+        fields = patch.model_dump(exclude_unset=True)
+        if not fields:
+            return await self.get(id)
+        set_clauses: list[str] = []
+        params: list[object] = []
+        for i, (col, val) in enumerate(fields.items(), start=1):
+            if col in ("structured", "external_refs", "metadata"):
+                set_clauses.append(f"{col} = ${i}::jsonb")
+                params.append(self._to_jsonb(val))
+            else:
+                set_clauses.append(f"{col} = ${i}")
+                params.append(val)
+        set_clauses.append("version = version + 1")
+        set_clauses.append("updated_at = NOW()")
+
+        if expected_version is not None:
+            sql = (
+                f"UPDATE wiki_pages SET {', '.join(set_clauses)} "
+                f"WHERE id = ${len(params) + 1} AND version = ${len(params) + 2} "
+                f"RETURNING *"
+            )
+            params.extend([id, expected_version])
+            row = await self._pool.fetchrow(sql, *params)
+            if row is None:
+                exists = await self._pool.fetchval(
+                    "SELECT 1 FROM wiki_pages WHERE id = $1", id,
+                )
+                if exists:
+                    raise WikiPageOptimisticLockError(
+                        f"version mismatch on wiki_page {id} "
+                        f"(expected={expected_version})",
+                    )
+                return None
+            return self._row_to_read(row)
+
+        sql = (
+            f"UPDATE wiki_pages SET {', '.join(set_clauses)} "
+            f"WHERE id = ${len(params) + 1} RETURNING *"
+        )
+        params.append(id)
+        row = await self._pool.fetchrow(sql, *params)
+        return self._row_to_read(row) if row else None
+
+    # ---- 특수 쿼리 ----
+
+    async def get_by_slug(self, slug: str) -> WikiPageRead | None:
+        row = await self._pool.fetchrow(
+            "SELECT * FROM wiki_pages WHERE slug = $1", slug,
+        )
+        return self._row_to_read(row) if row else None
+
+
+__all__ = ["WikiPageRepository", "WikiPageOptimisticLockError"]

--- a/mcp/document-db/src/document_db_mcp/schemas/__init__.py
+++ b/mcp/document-db/src/document_db_mcp/schemas/__init__.py
@@ -1,0 +1,36 @@
+"""Pydantic 모델 — collection 별 Create / Update / Read."""
+
+from document_db_mcp.schemas.agent_item import AgentItemCreate, AgentItemRead
+from document_db_mcp.schemas.agent_session import (
+    AgentSessionCreate,
+    AgentSessionRead,
+    AgentSessionUpdate,
+)
+from document_db_mcp.schemas.agent_task import (
+    AgentTaskCreate,
+    AgentTaskRead,
+    AgentTaskUpdate,
+)
+from document_db_mcp.schemas.issue import IssueCreate, IssueRead, IssueUpdate
+from document_db_mcp.schemas.wiki_page import (
+    WikiPageCreate,
+    WikiPageRead,
+    WikiPageUpdate,
+)
+
+__all__ = [
+    "AgentItemCreate",
+    "AgentItemRead",
+    "AgentSessionCreate",
+    "AgentSessionRead",
+    "AgentSessionUpdate",
+    "AgentTaskCreate",
+    "AgentTaskRead",
+    "AgentTaskUpdate",
+    "IssueCreate",
+    "IssueRead",
+    "IssueUpdate",
+    "WikiPageCreate",
+    "WikiPageRead",
+    "WikiPageUpdate",
+]

--- a/mcp/document-db/src/document_db_mcp/schemas/agent_item.py
+++ b/mcp/document-db/src/document_db_mcp/schemas/agent_item.py
@@ -1,0 +1,39 @@
+"""agent_items Pydantic 모델 (immutable, update 없음)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+AgentItemRole = Literal["user", "agent", "system"]
+
+
+class AgentItemCreate(BaseModel):
+    """대화 메시지 1건. 한 번 쓰면 변경 X (audit 성격)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    agent_session_id: UUID
+    prev_item_id: UUID | None = None
+    role: AgentItemRole
+    sender: str
+    content: dict[str, Any] | list[Any]   # A2A Message.parts 그대로
+    message_id: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class AgentItemRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    agent_session_id: UUID
+    prev_item_id: UUID | None
+    role: AgentItemRole
+    sender: str
+    content: Any
+    message_id: str | None
+    metadata: dict[str, Any]
+    created_at: datetime

--- a/mcp/document-db/src/document_db_mcp/schemas/agent_session.py
+++ b/mcp/document-db/src/document_db_mcp/schemas/agent_session.py
@@ -1,0 +1,47 @@
+"""agent_sessions Pydantic 모델."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class AgentSessionCreate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    agent_task_id: UUID
+    initiator: str
+    counterpart: str
+    context_id: str
+    trace_id: str | None = None
+    topic: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class AgentSessionUpdate(BaseModel):
+    """주로 ended_at / topic / metadata 갱신용."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    topic: str | None = None
+    trace_id: str | None = None
+    metadata: dict[str, Any] | None = None
+    ended_at: datetime | None = None
+
+
+class AgentSessionRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    agent_task_id: UUID
+    initiator: str
+    counterpart: str
+    context_id: str
+    trace_id: str | None
+    topic: str | None
+    metadata: dict[str, Any]
+    started_at: datetime
+    ended_at: datetime | None

--- a/mcp/document-db/src/document_db_mcp/schemas/agent_task.py
+++ b/mcp/document-db/src/document_db_mcp/schemas/agent_task.py
@@ -1,0 +1,53 @@
+"""agent_tasks Pydantic 모델."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+AgentTaskStatus = Literal["open", "in_progress", "done", "cancelled"]
+
+
+class AgentTaskCreate(BaseModel):
+    """create 입력 (id 미지정 — DB가 발급)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    title: str
+    description: str | None = None
+    status: AgentTaskStatus = "open"
+    owner_agent: str | None = None
+    issue_refs: list[UUID] = Field(default_factory=list)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class AgentTaskUpdate(BaseModel):
+    """update 입력 — 모든 필드 선택. 명시된 필드만 patch."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    title: str | None = None
+    description: str | None = None
+    status: AgentTaskStatus | None = None
+    owner_agent: str | None = None
+    issue_refs: list[UUID] | None = None
+    metadata: dict[str, Any] | None = None
+
+
+class AgentTaskRead(BaseModel):
+    """DB row → 외부 노출 형태."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    title: str
+    description: str | None
+    status: AgentTaskStatus
+    owner_agent: str | None
+    issue_refs: list[UUID]
+    metadata: dict[str, Any]
+    created_at: datetime
+    updated_at: datetime

--- a/mcp/document-db/src/document_db_mcp/schemas/issue.py
+++ b/mcp/document-db/src/document_db_mcp/schemas/issue.py
@@ -1,0 +1,60 @@
+"""issues Pydantic 모델."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+IssueType = Literal["epic", "story", "task"]
+IssueStatus = Literal["draft", "confirmed", "cancelled"]
+
+
+class IssueCreate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    agent_task_id: UUID | None = None
+    type: IssueType
+    title: str
+    body_md: str
+    status: IssueStatus = "draft"
+    parent_issue_id: UUID | None = None
+    labels: list[str] = Field(default_factory=list)
+    external_refs: dict[str, Any] = Field(default_factory=dict)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class IssueUpdate(BaseModel):
+    """update — 명시된 필드만 patch. version 은 optimistic concurrency 용 매개로 별도 인자."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    title: str | None = None
+    body_md: str | None = None
+    status: IssueStatus | None = None
+    parent_issue_id: UUID | None = None
+    labels: list[str] | None = None
+    external_refs: dict[str, Any] | None = None
+    last_synced_at: datetime | None = None
+    metadata: dict[str, Any] | None = None
+
+
+class IssueRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    agent_task_id: UUID | None
+    type: IssueType
+    title: str
+    body_md: str
+    status: IssueStatus
+    parent_issue_id: UUID | None
+    labels: list[str]
+    external_refs: dict[str, Any]
+    last_synced_at: datetime | None
+    metadata: dict[str, Any]
+    version: int
+    created_at: datetime
+    updated_at: datetime

--- a/mcp/document-db/src/document_db_mcp/schemas/wiki_page.py
+++ b/mcp/document-db/src/document_db_mcp/schemas/wiki_page.py
@@ -1,0 +1,69 @@
+"""wiki_pages Pydantic 모델."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+WikiPageType = Literal[
+    "prd", "business_rule", "data_model",
+    "adr", "api_contract",
+    "glossary", "runbook", "generic",
+]
+WikiPageStatus = Literal["draft", "confirmed", "cancelled"]
+
+
+class WikiPageCreate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    agent_task_id: UUID | None = None
+    page_type: WikiPageType
+    slug: str
+    title: str
+    content_md: str
+    status: WikiPageStatus = "draft"
+    author_agent: str | None = None
+    references_issues: list[UUID] = Field(default_factory=list)
+    references_pages: list[UUID] = Field(default_factory=list)
+    structured: dict[str, Any] = Field(default_factory=dict)
+    external_refs: dict[str, Any] = Field(default_factory=dict)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class WikiPageUpdate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    title: str | None = None
+    content_md: str | None = None
+    status: WikiPageStatus | None = None
+    references_issues: list[UUID] | None = None
+    references_pages: list[UUID] | None = None
+    structured: dict[str, Any] | None = None
+    external_refs: dict[str, Any] | None = None
+    last_synced_at: datetime | None = None
+    metadata: dict[str, Any] | None = None
+
+
+class WikiPageRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    agent_task_id: UUID | None
+    page_type: WikiPageType
+    slug: str
+    title: str
+    content_md: str
+    status: WikiPageStatus
+    author_agent: str | None
+    references_issues: list[UUID]
+    references_pages: list[UUID]
+    structured: dict[str, Any]
+    external_refs: dict[str, Any]
+    last_synced_at: datetime | None
+    metadata: dict[str, Any]
+    version: int
+    created_at: datetime
+    updated_at: datetime

--- a/mcp/document-db/src/document_db_mcp/server.py
+++ b/mcp/document-db/src/document_db_mcp/server.py
@@ -1,0 +1,31 @@
+"""Document DB MCP — entry point.
+
+본 모듈은 import side-effect 으로 모든 도구를 mcp 인스턴스에 등록한 뒤,
+streamable HTTP 로 서버를 기동한다.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from document_db_mcp import tools as _tools  # noqa: F401  (registers tools)
+from document_db_mcp.mcp_instance import mcp
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+def main() -> None:
+    """uvicorn 위에서 streamable HTTP 서버 기동."""
+    logger.info("starting document-db-mcp (streamable HTTP)")
+    mcp.run(transport="streamable-http")
+
+
+if __name__ == "__main__":
+    main()
+
+
+__all__ = ["main"]

--- a/mcp/document-db/src/document_db_mcp/tools/__init__.py
+++ b/mcp/document-db/src/document_db_mcp/tools/__init__.py
@@ -1,0 +1,16 @@
+"""tools/ — MCP 도구 등록.
+
+본 패키지를 import 하면 각 collection 모듈이 module-level `@mcp.tool()` 데코레이터로
+자동 등록됨. 새 collection 추가 시 본 파일에 import 1줄 추가.
+"""
+
+# noqa: F401  # imports below are for side-effect (decorator registration)
+from document_db_mcp.tools import (
+    agent_item,
+    agent_session,
+    agent_task,
+    issue,
+    wiki_page,
+)
+
+__all__: list[str] = []

--- a/mcp/document-db/src/document_db_mcp/tools/agent_item.py
+++ b/mcp/document-db/src/document_db_mcp/tools/agent_item.py
@@ -1,0 +1,60 @@
+"""agent_items MCP 도구 — items 는 immutable. update/upsert 미노출."""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from mcp.server.fastmcp import Context
+
+from document_db_mcp.mcp_instance import AppContext, mcp
+from document_db_mcp.repositories.base import ListFilter
+from document_db_mcp.schemas.agent_item import AgentItemCreate
+
+
+def _ctx(ctx: Context) -> AppContext:
+    return ctx.request_context.lifespan_context  # type: ignore[return-value]
+
+
+@mcp.tool(name="agent_item.create", description="Append an item (immutable).")
+async def create(ctx: Context, doc: dict[str, Any]) -> dict[str, Any]:
+    repo = _ctx(ctx).agent_item
+    return (await repo.create(AgentItemCreate.model_validate(doc))).model_dump(mode="json")
+
+
+@mcp.tool(name="agent_item.get")
+async def get(ctx: Context, id: str) -> dict[str, Any] | None:
+    result = await _ctx(ctx).agent_item.get(UUID(id))
+    return result.model_dump(mode="json") if result else None
+
+
+@mcp.tool(name="agent_item.list")
+async def list_(
+    ctx: Context,
+    where: dict[str, Any] | None = None,
+    limit: int = 200,
+    offset: int = 0,
+    order_by: str = "created_at",
+) -> list[dict[str, Any]]:
+    flt = ListFilter(where=where, limit=limit, offset=offset, order_by=order_by)
+    items = await _ctx(ctx).agent_item.list(flt)
+    return [it.model_dump(mode="json") for it in items]
+
+
+@mcp.tool(name="agent_item.delete")
+async def delete(ctx: Context, id: str) -> bool:
+    return await _ctx(ctx).agent_item.delete(UUID(id))
+
+
+@mcp.tool(name="agent_item.count")
+async def count(ctx: Context, where: dict[str, Any] | None = None) -> int:
+    return await _ctx(ctx).agent_item.count(where)
+
+
+@mcp.tool(
+    name="agent_item.list_by_session",
+    description="List items in a session, ordered by created_at.",
+)
+async def list_by_session(ctx: Context, agent_session_id: str) -> list[dict[str, Any]]:
+    items = await _ctx(ctx).agent_item.list_by_session(UUID(agent_session_id))
+    return [it.model_dump(mode="json") for it in items]

--- a/mcp/document-db/src/document_db_mcp/tools/agent_session.py
+++ b/mcp/document-db/src/document_db_mcp/tools/agent_session.py
@@ -1,0 +1,79 @@
+"""agent_sessions MCP 도구."""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from mcp.server.fastmcp import Context
+
+from document_db_mcp.mcp_instance import AppContext, mcp
+from document_db_mcp.repositories.base import ListFilter
+from document_db_mcp.schemas.agent_session import AgentSessionCreate, AgentSessionUpdate
+
+
+def _ctx(ctx: Context) -> AppContext:
+    return ctx.request_context.lifespan_context  # type: ignore[return-value]
+
+
+@mcp.tool(name="agent_session.upsert")
+async def upsert(
+    ctx: Context,
+    doc: dict[str, Any],
+    id: str | None = None,
+) -> dict[str, Any]:
+    repo = _ctx(ctx).agent_session
+    if id:
+        patch = AgentSessionUpdate.model_validate(doc)
+        updated = await repo.update(UUID(id), patch)
+        if updated is None:
+            return (await repo.create(AgentSessionCreate.model_validate(doc))).model_dump(mode="json")
+        return updated.model_dump(mode="json")
+    return (await repo.create(AgentSessionCreate.model_validate(doc))).model_dump(mode="json")
+
+
+@mcp.tool(name="agent_session.get")
+async def get(ctx: Context, id: str) -> dict[str, Any] | None:
+    result = await _ctx(ctx).agent_session.get(UUID(id))
+    return result.model_dump(mode="json") if result else None
+
+
+@mcp.tool(name="agent_session.list")
+async def list_(
+    ctx: Context,
+    where: dict[str, Any] | None = None,
+    limit: int = 100,
+    offset: int = 0,
+    order_by: str = "started_at DESC",
+) -> list[dict[str, Any]]:
+    flt = ListFilter(where=where, limit=limit, offset=offset, order_by=order_by)
+    items = await _ctx(ctx).agent_session.list(flt)
+    return [it.model_dump(mode="json") for it in items]
+
+
+@mcp.tool(name="agent_session.delete")
+async def delete(ctx: Context, id: str) -> bool:
+    return await _ctx(ctx).agent_session.delete(UUID(id))
+
+
+@mcp.tool(name="agent_session.count")
+async def count(ctx: Context, where: dict[str, Any] | None = None) -> int:
+    return await _ctx(ctx).agent_session.count(where)
+
+
+@mcp.tool(
+    name="agent_session.list_by_task",
+    description="List sessions in a given agent_task, ordered by started_at.",
+)
+async def list_by_task(ctx: Context, agent_task_id: str) -> list[dict[str, Any]]:
+    items = await _ctx(ctx).agent_session.list_by_task(UUID(agent_task_id))
+    return [it.model_dump(mode="json") for it in items]
+
+
+@mcp.tool(
+    name="agent_session.find_by_context",
+    description="Find the most recent session by A2A context_id.",
+)
+async def find_by_context(ctx: Context, context_id: str) -> dict[str, Any] | None:
+    result = await _ctx(ctx).agent_session.find_by_context(context_id)
+    return result.model_dump(mode="json") if result else None

--- a/mcp/document-db/src/document_db_mcp/tools/agent_task.py
+++ b/mcp/document-db/src/document_db_mcp/tools/agent_task.py
@@ -1,0 +1,62 @@
+"""agent_tasks MCP 도구."""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from mcp.server.fastmcp import Context
+
+from document_db_mcp.mcp_instance import AppContext, mcp
+from document_db_mcp.repositories.base import ListFilter
+from document_db_mcp.schemas.agent_task import AgentTaskCreate, AgentTaskUpdate
+
+
+def _ctx(ctx: Context) -> AppContext:
+    """lifespan 의 AppContext 를 꺼냄. type-narrowed alias."""
+    return ctx.request_context.lifespan_context  # type: ignore[return-value]
+
+
+@mcp.tool(name="agent_task.upsert", description="Create or update an agent_task.")
+async def upsert(
+    ctx: Context,
+    doc: dict[str, Any],
+    id: str | None = None,
+) -> dict[str, Any]:
+    repo = _ctx(ctx).agent_task
+    if id:
+        patch = AgentTaskUpdate.model_validate(doc)
+        updated = await repo.update(UUID(id), patch)
+        if updated is None:
+            return (await repo.create(AgentTaskCreate.model_validate(doc))).model_dump(mode="json")
+        return updated.model_dump(mode="json")
+    return (await repo.create(AgentTaskCreate.model_validate(doc))).model_dump(mode="json")
+
+
+@mcp.tool(name="agent_task.get", description="Get an agent_task by id.")
+async def get(ctx: Context, id: str) -> dict[str, Any] | None:
+    result = await _ctx(ctx).agent_task.get(UUID(id))
+    return result.model_dump(mode="json") if result else None
+
+
+@mcp.tool(name="agent_task.list", description="List agent_tasks with optional filter.")
+async def list_(
+    ctx: Context,
+    where: dict[str, Any] | None = None,
+    limit: int = 100,
+    offset: int = 0,
+    order_by: str = "created_at DESC",
+) -> list[dict[str, Any]]:
+    flt = ListFilter(where=where, limit=limit, offset=offset, order_by=order_by)
+    items = await _ctx(ctx).agent_task.list(flt)
+    return [it.model_dump(mode="json") for it in items]
+
+
+@mcp.tool(name="agent_task.delete", description="Delete an agent_task by id.")
+async def delete(ctx: Context, id: str) -> bool:
+    return await _ctx(ctx).agent_task.delete(UUID(id))
+
+
+@mcp.tool(name="agent_task.count", description="Count agent_tasks.")
+async def count(ctx: Context, where: dict[str, Any] | None = None) -> int:
+    return await _ctx(ctx).agent_task.count(where)

--- a/mcp/document-db/src/document_db_mcp/tools/issue.py
+++ b/mcp/document-db/src/document_db_mcp/tools/issue.py
@@ -1,0 +1,71 @@
+"""issues MCP 도구 — 5 op + optimistic locking."""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from mcp.server.fastmcp import Context
+
+from document_db_mcp.mcp_instance import AppContext, mcp
+from document_db_mcp.repositories.base import ListFilter
+from document_db_mcp.repositories.issue import IssueOptimisticLockError
+from document_db_mcp.schemas.issue import IssueCreate, IssueUpdate
+
+
+def _ctx(ctx: Context) -> AppContext:
+    return ctx.request_context.lifespan_context  # type: ignore[return-value]
+
+
+@mcp.tool(
+    name="issue.upsert",
+    description="Create or update an issue. expected_version for optimistic locking.",
+)
+async def upsert(
+    ctx: Context,
+    doc: dict[str, Any],
+    id: str | None = None,
+    expected_version: int | None = None,
+) -> dict[str, Any]:
+    repo = _ctx(ctx).issue
+    if id:
+        patch = IssueUpdate.model_validate(doc)
+        try:
+            updated = await repo.update_with_version(
+                UUID(id), patch, expected_version=expected_version,
+            )
+        except IssueOptimisticLockError as e:
+            raise RuntimeError(str(e)) from e
+        if updated is None:
+            return (await repo.create(IssueCreate.model_validate(doc))).model_dump(mode="json")
+        return updated.model_dump(mode="json")
+    return (await repo.create(IssueCreate.model_validate(doc))).model_dump(mode="json")
+
+
+@mcp.tool(name="issue.get")
+async def get(ctx: Context, id: str) -> dict[str, Any] | None:
+    result = await _ctx(ctx).issue.get(UUID(id))
+    return result.model_dump(mode="json") if result else None
+
+
+@mcp.tool(name="issue.list")
+async def list_(
+    ctx: Context,
+    where: dict[str, Any] | None = None,
+    limit: int = 100,
+    offset: int = 0,
+    order_by: str = "created_at DESC",
+) -> list[dict[str, Any]]:
+    flt = ListFilter(where=where, limit=limit, offset=offset, order_by=order_by)
+    items = await _ctx(ctx).issue.list(flt)
+    return [it.model_dump(mode="json") for it in items]
+
+
+@mcp.tool(name="issue.delete")
+async def delete(ctx: Context, id: str) -> bool:
+    return await _ctx(ctx).issue.delete(UUID(id))
+
+
+@mcp.tool(name="issue.count")
+async def count(ctx: Context, where: dict[str, Any] | None = None) -> int:
+    return await _ctx(ctx).issue.count(where)

--- a/mcp/document-db/src/document_db_mcp/tools/wiki_page.py
+++ b/mcp/document-db/src/document_db_mcp/tools/wiki_page.py
@@ -1,0 +1,77 @@
+"""wiki_pages MCP 도구 — 5 op + get_by_slug + optimistic locking."""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from mcp.server.fastmcp import Context
+
+from document_db_mcp.mcp_instance import AppContext, mcp
+from document_db_mcp.repositories.base import ListFilter
+from document_db_mcp.repositories.wiki_page import WikiPageOptimisticLockError
+from document_db_mcp.schemas.wiki_page import WikiPageCreate, WikiPageUpdate
+
+
+def _ctx(ctx: Context) -> AppContext:
+    return ctx.request_context.lifespan_context  # type: ignore[return-value]
+
+
+@mcp.tool(
+    name="wiki_page.upsert",
+    description="Create or update a wiki page. expected_version for optimistic locking.",
+)
+async def upsert(
+    ctx: Context,
+    doc: dict[str, Any],
+    id: str | None = None,
+    expected_version: int | None = None,
+) -> dict[str, Any]:
+    repo = _ctx(ctx).wiki_page
+    if id:
+        patch = WikiPageUpdate.model_validate(doc)
+        try:
+            updated = await repo.update_with_version(
+                UUID(id), patch, expected_version=expected_version,
+            )
+        except WikiPageOptimisticLockError as e:
+            raise RuntimeError(str(e)) from e
+        if updated is None:
+            return (await repo.create(WikiPageCreate.model_validate(doc))).model_dump(mode="json")
+        return updated.model_dump(mode="json")
+    return (await repo.create(WikiPageCreate.model_validate(doc))).model_dump(mode="json")
+
+
+@mcp.tool(name="wiki_page.get")
+async def get(ctx: Context, id: str) -> dict[str, Any] | None:
+    result = await _ctx(ctx).wiki_page.get(UUID(id))
+    return result.model_dump(mode="json") if result else None
+
+
+@mcp.tool(name="wiki_page.list")
+async def list_(
+    ctx: Context,
+    where: dict[str, Any] | None = None,
+    limit: int = 100,
+    offset: int = 0,
+    order_by: str = "created_at DESC",
+) -> list[dict[str, Any]]:
+    flt = ListFilter(where=where, limit=limit, offset=offset, order_by=order_by)
+    items = await _ctx(ctx).wiki_page.list(flt)
+    return [it.model_dump(mode="json") for it in items]
+
+
+@mcp.tool(name="wiki_page.delete")
+async def delete(ctx: Context, id: str) -> bool:
+    return await _ctx(ctx).wiki_page.delete(UUID(id))
+
+
+@mcp.tool(name="wiki_page.count")
+async def count(ctx: Context, where: dict[str, Any] | None = None) -> int:
+    return await _ctx(ctx).wiki_page.count(where)
+
+
+@mcp.tool(name="wiki_page.get_by_slug", description="Get a wiki page by its slug.")
+async def get_by_slug(ctx: Context, slug: str) -> dict[str, Any] | None:
+    result = await _ctx(ctx).wiki_page.get_by_slug(slug)
+    return result.model_dump(mode="json") if result else None

--- a/mcp/document-db/tests/test_repositories.py
+++ b/mcp/document-db/tests/test_repositories.py
@@ -1,0 +1,149 @@
+"""Repository 통합 테스트 — 실 Postgres 사용.
+
+`docker compose --profile mcp up -d` 가 띄운 Postgres `dev_team` DB 에 직접 연결.
+독립 실행을 원하면 testcontainers 도입 (M5+).
+
+CI 자동화를 위해 환경변수 `DOC_DB_TEST_DSN` 으로 별 DB 지정 가능.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from collections.abc import AsyncIterator
+
+import asyncpg
+import pytest
+import pytest_asyncio
+
+from document_db_mcp.repositories import (
+    AgentItemRepository,
+    AgentSessionRepository,
+    AgentTaskRepository,
+    IssueRepository,
+    WikiPageRepository,
+)
+from document_db_mcp.schemas import (
+    AgentItemCreate,
+    AgentSessionCreate,
+    AgentTaskCreate,
+    AgentTaskUpdate,
+    IssueCreate,
+    IssueUpdate,
+    WikiPageCreate,
+)
+
+_DSN = os.environ.get(
+    "DOC_DB_TEST_DSN",
+    "postgres://devteam:devteam_postgres@localhost:5432/dev_team",
+)
+
+
+@pytest_asyncio.fixture
+async def pool() -> AsyncIterator[asyncpg.Pool]:
+    p = await asyncpg.create_pool(dsn=_DSN, min_size=1, max_size=2)
+    try:
+        # 각 테스트 시작 시 전체 정리 (간단한 인프라 — production 와 충돌 X 가정)
+        async with p.acquire() as conn:
+            await conn.execute(
+                "TRUNCATE agent_items, agent_sessions, agent_tasks, "
+                "issues, wiki_pages RESTART IDENTITY CASCADE",
+            )
+        yield p
+    finally:
+        await p.close()
+
+
+class TestAgentTaskRepository:
+    async def test_create_and_get(self, pool: asyncpg.Pool) -> None:
+        repo = AgentTaskRepository(pool)
+        created = await repo.create(AgentTaskCreate(title="t1"))
+        fetched = await repo.get(created.id)
+        assert fetched is not None
+        assert fetched.title == "t1"
+        assert fetched.status == "open"
+
+    async def test_update_patch(self, pool: asyncpg.Pool) -> None:
+        repo = AgentTaskRepository(pool)
+        created = await repo.create(AgentTaskCreate(title="t1"))
+        updated = await repo.update(created.id, AgentTaskUpdate(status="done"))
+        assert updated is not None
+        assert updated.status == "done"
+        assert updated.title == "t1"   # patch 는 명시 필드만
+
+    async def test_list_count_delete(self, pool: asyncpg.Pool) -> None:
+        repo = AgentTaskRepository(pool)
+        await repo.create(AgentTaskCreate(title="a"))
+        await repo.create(AgentTaskCreate(title="b"))
+        assert await repo.count() == 2
+        items = await repo.list()
+        assert len(items) == 2
+        deleted = await repo.delete(items[0].id)
+        assert deleted is True
+        assert await repo.count() == 1
+
+
+class TestIssueRepository:
+    async def test_create_with_optimistic_locking(self, pool: asyncpg.Pool) -> None:
+        repo = IssueRepository(pool)
+        created = await repo.create(IssueCreate(type="story", title="X", body_md="..."))
+        assert created.version == 1
+        # 정상 update
+        upd = await repo.update_with_version(
+            created.id,
+            IssueUpdate(status="confirmed"),
+            expected_version=1,
+        )
+        assert upd is not None
+        assert upd.version == 2
+        assert upd.status == "confirmed"
+
+
+class TestAgentSessionAndItem:
+    async def test_chronicler_chain(self, pool: asyncpg.Pool) -> None:
+        task_repo = AgentTaskRepository(pool)
+        session_repo = AgentSessionRepository(pool)
+        item_repo = AgentItemRepository(pool)
+
+        task = await task_repo.create(AgentTaskCreate(title="conv"))
+        session = await session_repo.create(AgentSessionCreate(
+            agent_task_id=task.id,
+            initiator="user",
+            counterpart="primary",
+            context_id="ctx-1",
+        ))
+        item1 = await item_repo.create(AgentItemCreate(
+            agent_session_id=session.id,
+            role="user",
+            sender="user",
+            content={"text": "hi"},
+        ))
+        item2 = await item_repo.create(AgentItemCreate(
+            agent_session_id=session.id,
+            prev_item_id=item1.id,
+            role="agent",
+            sender="primary",
+            content={"text": "hello"},
+        ))
+        items = await item_repo.list_by_session(session.id)
+        assert [i.id for i in items] == [item1.id, item2.id]
+        # 특수 쿼리
+        found = await session_repo.find_by_context("ctx-1")
+        assert found is not None and found.id == session.id
+
+
+class TestWikiPageRepository:
+    async def test_slug_unique_and_get_by_slug(self, pool: asyncpg.Pool) -> None:
+        repo = WikiPageRepository(pool)
+        slug = f"prd-{uuid.uuid4().hex[:8]}"
+        await repo.create(WikiPageCreate(
+            page_type="prd", slug=slug, title="T", content_md="body",
+        ))
+        # 같은 slug 재시도 → 무결성 위반
+        with pytest.raises(asyncpg.UniqueViolationError):
+            await repo.create(WikiPageCreate(
+                page_type="prd", slug=slug, title="T2", content_md="body2",
+            ))
+        # get_by_slug
+        fetched = await repo.get_by_slug(slug)
+        assert fetched is not None and fetched.slug == slug

--- a/mcp/document-db/tests/test_schemas.py
+++ b/mcp/document-db/tests/test_schemas.py
@@ -1,0 +1,103 @@
+"""Pydantic 스키마 단위 테스트 — DB / 컨테이너 의존 없음."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from document_db_mcp.schemas import (
+    AgentItemCreate,
+    AgentSessionCreate,
+    AgentTaskCreate,
+    IssueCreate,
+    WikiPageCreate,
+)
+
+
+class TestAgentTaskCreate:
+    def test_minimal(self) -> None:
+        doc = AgentTaskCreate(title="hello")
+        assert doc.status == "open"
+        assert doc.metadata == {}
+        assert doc.issue_refs == []
+
+    def test_invalid_status(self) -> None:
+        with pytest.raises(ValidationError):
+            AgentTaskCreate(title="x", status="bogus")  # type: ignore[arg-type]
+
+    def test_extra_field_forbidden(self) -> None:
+        with pytest.raises(ValidationError):
+            AgentTaskCreate(title="x", unknown_field=1)  # type: ignore[call-arg]
+
+
+class TestIssueCreate:
+    def test_type_required(self) -> None:
+        with pytest.raises(ValidationError):
+            IssueCreate(title="t", body_md="b")  # type: ignore[call-arg]
+
+    def test_valid_types(self) -> None:
+        for t in ("epic", "story", "task"):
+            doc = IssueCreate(type=t, title="t", body_md="b")  # type: ignore[arg-type]
+            assert doc.status == "draft"
+
+    def test_invalid_type(self) -> None:
+        with pytest.raises(ValidationError):
+            IssueCreate(type="bug", title="t", body_md="b")  # type: ignore[arg-type]
+
+
+class TestWikiPageCreate:
+    def test_all_page_types_accepted(self) -> None:
+        types = (
+            "prd", "business_rule", "data_model",
+            "adr", "api_contract",
+            "glossary", "runbook", "generic",
+        )
+        for t in types:
+            WikiPageCreate(
+                page_type=t,  # type: ignore[arg-type]
+                slug=f"slug-{t}",
+                title="t",
+                content_md="body",
+            )
+
+    def test_unknown_page_type(self) -> None:
+        with pytest.raises(ValidationError):
+            WikiPageCreate(
+                page_type="meeting_minutes",  # type: ignore[arg-type]
+                slug="x",
+                title="t",
+                content_md="b",
+            )
+
+
+class TestAgentSessionCreate:
+    def test_minimal(self) -> None:
+        doc = AgentSessionCreate(
+            agent_task_id=uuid4(),
+            initiator="user",
+            counterpart="primary",
+            context_id="ctx-1",
+        )
+        assert doc.trace_id is None
+
+
+class TestAgentItemCreate:
+    def test_role_validation(self) -> None:
+        for r in ("user", "agent", "system"):
+            AgentItemCreate(
+                agent_session_id=uuid4(),
+                role=r,  # type: ignore[arg-type]
+                sender="primary",
+                content={"text": "hi"},
+            )
+
+    def test_invalid_role(self) -> None:
+        with pytest.raises(ValidationError):
+            AgentItemCreate(
+                agent_session_id=uuid4(),
+                role="bot",  # type: ignore[arg-type]
+                sender="x",
+                content={},
+            )

--- a/mcp/document-db/uv.lock
+++ b/mcp/document-db/uv.lock
@@ -1,0 +1,908 @@
+version = 1
+revision = 3
+requires-python = "==3.13.*"
+
+[[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
+name = "asyncpg"
+version = "0.31.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/cc/d18065ce2380d80b1bcce927c24a2642efd38918e33fd724bc4bca904877/asyncpg-0.31.0.tar.gz", hash = "sha256:c989386c83940bfbd787180f2b1519415e2d3d6277a70d9d0f0145ac73500735", size = 993667, upload-time = "2025-11-24T23:27:00.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/11/97b5c2af72a5d0b9bc3fa30cd4b9ce22284a9a943a150fdc768763caf035/asyncpg-0.31.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c204fab1b91e08b0f47e90a75d1b3c62174dab21f670ad6c5d0f243a228f015b", size = 661111, upload-time = "2025-11-24T23:26:04.467Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/71/157d611c791a5e2d0423f09f027bd499935f0906e0c2a416ce712ba51ef3/asyncpg-0.31.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:54a64f91839ba59008eccf7aad2e93d6e3de688d796f35803235ea1c4898ae1e", size = 636928, upload-time = "2025-11-24T23:26:05.944Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/fc/9e3486fb2bbe69d4a867c0b76d68542650a7ff1574ca40e84c3111bb0c6e/asyncpg-0.31.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0e0822b1038dc7253b337b0f3f676cadc4ac31b126c5d42691c39691962e403", size = 3424067, upload-time = "2025-11-24T23:26:07.957Z" },
+    { url = "https://files.pythonhosted.org/packages/12/c6/8c9d076f73f07f995013c791e018a1cd5f31823c2a3187fc8581706aa00f/asyncpg-0.31.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bef056aa502ee34204c161c72ca1f3c274917596877f825968368b2c33f585f4", size = 3518156, upload-time = "2025-11-24T23:26:09.591Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3b/60683a0baf50fbc546499cfb53132cb6835b92b529a05f6a81471ab60d0c/asyncpg-0.31.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:0bfbcc5b7ffcd9b75ab1558f00db2ae07db9c80637ad1b2469c43df79d7a5ae2", size = 3319636, upload-time = "2025-11-24T23:26:11.168Z" },
+    { url = "https://files.pythonhosted.org/packages/50/dc/8487df0f69bd398a61e1792b3cba0e47477f214eff085ba0efa7eac9ce87/asyncpg-0.31.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:22bc525ebbdc24d1261ecbf6f504998244d4e3be1721784b5f64664d61fbe602", size = 3472079, upload-time = "2025-11-24T23:26:13.164Z" },
+    { url = "https://files.pythonhosted.org/packages/13/a1/c5bbeeb8531c05c89135cb8b28575ac2fac618bcb60119ee9696c3faf71c/asyncpg-0.31.0-cp313-cp313-win32.whl", hash = "sha256:f890de5e1e4f7e14023619399a471ce4b71f5418cd67a51853b9910fdfa73696", size = 527606, upload-time = "2025-11-24T23:26:14.78Z" },
+    { url = "https://files.pythonhosted.org/packages/91/66/b25ccb84a246b470eb943b0107c07edcae51804912b824054b3413995a10/asyncpg-0.31.0-cp313-cp313-win_amd64.whl", hash = "sha256:dc5f2fa9916f292e5c5c8b2ac2813763bcd7f58e130055b4ad8a0531314201ab", size = 596569, upload-time = "2025-11-24T23:26:16.189Z" },
+]
+
+[[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.4.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/ee/6caf7a40c36a1220410afe15a1cc64993a1f864871f698c0f93acb72842a/certifi-2026.4.22.tar.gz", hash = "sha256:8d455352a37b71bf76a79caa83a3d6c25afee4a385d632127b6afb3963f1c580", size = 137077, upload-time = "2026-04-22T11:26:11.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl", hash = "sha256:3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a", size = 135707, upload-time = "2026-04-22T11:26:09.372Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063", size = 309627, upload-time = "2026-04-02T09:26:45.198Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c", size = 207008, upload-time = "2026-04-02T09:26:46.824Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/bb/ec73c0257c9e11b268f018f068f5d00aa0ef8c8b09f7753ebd5f2880e248/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66", size = 228303, upload-time = "2026-04-02T09:26:48.397Z" },
+    { url = "https://files.pythonhosted.org/packages/85/fb/32d1f5033484494619f701e719429c69b766bfc4dbc61aa9e9c8c166528b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18", size = 224282, upload-time = "2026-04-02T09:26:49.684Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd", size = 215595, upload-time = "2026-04-02T09:26:50.915Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7c/fc890655786e423f02556e0216d4b8c6bcb6bdfa890160dc66bf52dee468/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215", size = 201986, upload-time = "2026-04-02T09:26:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/97/bfb18b3db2aed3b90cf54dc292ad79fdd5ad65c4eae454099475cbeadd0d/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859", size = 211711, upload-time = "2026-04-02T09:26:53.49Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/a5/a581c13798546a7fd557c82614a5c65a13df2157e9ad6373166d2a3e645d/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8", size = 210036, upload-time = "2026-04-02T09:26:54.975Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/bf/b3ab5bcb478e4193d517644b0fb2bf5497fbceeaa7a1bc0f4d5b50953861/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5", size = 202998, upload-time = "2026-04-02T09:26:56.303Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/4e/23efd79b65d314fa320ec6017b4b5834d5c12a58ba4610aa353af2e2f577/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832", size = 230056, upload-time = "2026-04-02T09:26:57.554Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9f/1e1941bc3f0e01df116e68dc37a55c4d249df5e6fa77f008841aef68264f/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6", size = 211537, upload-time = "2026-04-02T09:26:58.843Z" },
+    { url = "https://files.pythonhosted.org/packages/80/0f/088cbb3020d44428964a6c97fe1edfb1b9550396bf6d278330281e8b709c/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48", size = 226176, upload-time = "2026-04-02T09:27:00.437Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/9f/130394f9bbe06f4f63e22641d32fc9b202b7e251c9aef4db044324dac493/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a", size = 217723, upload-time = "2026-04-02T09:27:02.021Z" },
+    { url = "https://files.pythonhosted.org/packages/73/55/c469897448a06e49f8fa03f6caae97074fde823f432a98f979cc42b90e69/charset_normalizer-3.4.7-cp313-cp313-win32.whl", hash = "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e", size = 148085, upload-time = "2026-04-02T09:27:03.192Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110", size = 158819, upload-time = "2026-04-02T09:27:04.454Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/46bd42279d323deb8687c4a5a811fd548cb7d1de10cf6535d099877a9a9f/charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b", size = 147915, upload-time = "2026-04-02T09:27:05.971Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/63/f9e1ea081ce35720d8b92acde70daaedace594dc93b693c869e0d5910718/click-8.3.3.tar.gz", hash = "sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2", size = 328061, upload-time = "2026-04-22T15:11:27.506Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/44/c1221527f6a71a01ec6fbad7fa78f1d50dfa02217385cf0fa3eec7087d59/click-8.3.3-py3-none-any.whl", hash = "sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613", size = 110502, upload-time = "2026-04-22T15:11:25.044Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "cryptography"
+version = "47.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ef/b2/7ffa7fe8207a8c42147ffe70c3e360b228160c1d85dc3faff16aaa3244c0/cryptography-47.0.0.tar.gz", hash = "sha256:9f8e55fe4e63613a5e1cc5819030f27b97742d720203a087802ce4ce9ceb52bb", size = 830863, upload-time = "2026-04-24T19:54:57.056Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/98/40dfe932134bdcae4f6ab5927c87488754bf9eb79297d7e0070b78dd58e9/cryptography-47.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:160ad728f128972d362e714054f6ba0067cab7fb350c5202a9ae8ae4ce3ef1a0", size = 7912214, upload-time = "2026-04-24T19:53:03.864Z" },
+    { url = "https://files.pythonhosted.org/packages/34/c6/2733531243fba725f58611b918056b277692f1033373dcc8bd01af1c05d4/cryptography-47.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b9a8943e359b7615db1a3ba587994618e094ff3d6fa5a390c73d079ce18b3973", size = 4644617, upload-time = "2026-04-24T19:53:06.909Z" },
+    { url = "https://files.pythonhosted.org/packages/00/e3/b27be1a670a9b87f855d211cf0e1174a5d721216b7616bd52d8581d912ed/cryptography-47.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f5c15764f261394b22aef6b00252f5195f46f2ca300bec57149474e2538b31f8", size = 4668186, upload-time = "2026-04-24T19:53:09.053Z" },
+    { url = "https://files.pythonhosted.org/packages/81/b9/8443cfe5d17d482d348cee7048acf502bb89a51b6382f06240fd290d4ca3/cryptography-47.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:9c59ab0e0fa3a180a5a9c59f3a5abe3ef90d474bc56d7fadfbe80359491b615b", size = 4651244, upload-time = "2026-04-24T19:53:11.217Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/5e/13ed0cdd0eb88ba159d6dd5ebfece8cb901dbcf1ae5ac4072e28b55d3153/cryptography-47.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:34b4358b925a5ea3e14384ca781a2c0ef7ac219b57bb9eacc4457078e2b19f92", size = 5252906, upload-time = "2026-04-24T19:53:13.532Z" },
+    { url = "https://files.pythonhosted.org/packages/64/16/ed058e1df0f33d440217cd120d41d5dda9dd215a80b8187f68483185af82/cryptography-47.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:0024b87d47ae2399165a6bfb20d24888881eeab83ae2566d62467c5ff0030ce7", size = 4701842, upload-time = "2026-04-24T19:53:15.618Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3d30986b30fdbd9e969abbdf8ba00ed0618615144341faeb57f395a084fe/cryptography-47.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:1e47422b5557bb82d3fff997e8d92cff4e28b9789576984f08c248d2b3535d93", size = 4289313, upload-time = "2026-04-24T19:53:17.755Z" },
+    { url = "https://files.pythonhosted.org/packages/df/fd/32db38e3ad0cb331f0691cb4c7a8a6f176f679124dee746b3af6633db4d9/cryptography-47.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:6f29f36582e6151d9686235e586dd35bb67491f024767d10b842e520dc6a07ac", size = 4650964, upload-time = "2026-04-24T19:53:20.062Z" },
+    { url = "https://files.pythonhosted.org/packages/86/53/5395d944dfd48cb1f67917f533c609c34347185ef15eb4308024c876f274/cryptography-47.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:a9b761f012a943b7de0e828843c5688d0de94a0578d44d6c85a1bae32f87791f", size = 5207817, upload-time = "2026-04-24T19:53:22.498Z" },
+    { url = "https://files.pythonhosted.org/packages/34/4f/e5711b28e1901f7d480a2b1b688b645aa4c77c73f10731ed17e7f7db3f0d/cryptography-47.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:4e1de79e047e25d6e9f8cea71c86b4a53aced64134f0f003bbcbf3655fd172c8", size = 4701544, upload-time = "2026-04-24T19:53:24.356Z" },
+    { url = "https://files.pythonhosted.org/packages/22/22/c8ddc25de3010fc8da447648f5a092c40e7a8fadf01dd6d255d9c0b9373d/cryptography-47.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:ef6b3634087f18d2155b1e8ce264e5345a753da2c5fa9815e7d41315c90f8318", size = 4783536, upload-time = "2026-04-24T19:53:26.665Z" },
+    { url = "https://files.pythonhosted.org/packages/66/b6/d4a68f4ea999c6d89e8498579cba1c5fcba4276284de7773b17e4fa69293/cryptography-47.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:11dbb9f50a0f1bb9757b3d8c27c1101780efb8f0bdecfb12439c22a74d64c001", size = 4926106, upload-time = "2026-04-24T19:53:28.686Z" },
+    { url = "https://files.pythonhosted.org/packages/54/ed/5f524db1fade9c013aa618e1c99c6ed05e8ffc9ceee6cda22fed22dda3f4/cryptography-47.0.0-cp311-abi3-win32.whl", hash = "sha256:7fda2f02c9015db3f42bb8a22324a454516ed10a8c29ca6ece6cdbb5efe2a203", size = 3258581, upload-time = "2026-04-24T19:53:31.058Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/dc/1b901990b174786569029f67542b3edf72ac068b6c3c8683c17e6a2f5363/cryptography-47.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:f5c3296dab66202f1b18a91fa266be93d6aa0c2806ea3d67762c69f60adc71aa", size = 3775309, upload-time = "2026-04-24T19:53:33.054Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/34/a4fae8ae7c3bc227460c9ae43f56abf1b911da0ec29e0ebac53bb0a4b6b7/cryptography-47.0.0-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:14432c8a9bcb37009784f9594a62fae211a2ae9543e96c92b2a8e4c3cd5cd0c4", size = 7904072, upload-time = "2026-04-24T19:54:06.411Z" },
+    { url = "https://files.pythonhosted.org/packages/01/64/d7b1e54fdb69f22d24a64bb3e88dc718b31c7fb10ef0b9691a3cf7eeea6e/cryptography-47.0.0-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:07efe86201817e7d3c18781ca9770bc0db04e1e48c994be384e4602bc38f8f27", size = 4635767, upload-time = "2026-04-24T19:54:08.519Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/7b/cca826391fb2a94efdcdfe4631eb69306ee1cff0b22f664a412c90713877/cryptography-47.0.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2b45761c6ec22b7c726d6a829558777e32d0f1c8be7c3f3480f9c912d5ee8a10", size = 4654350, upload-time = "2026-04-24T19:54:10.795Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/65/4b57bcc823f42a991627c51c2f68c9fd6eb1393c1756aac876cba2accae2/cryptography-47.0.0-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:edd4da498015da5b9f26d38d3bfc2e90257bfa9cbed1f6767c282a0025ae649b", size = 4643394, upload-time = "2026-04-24T19:54:13.275Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/c4/2c5fbeea70adbbca2bbae865e1d605d6a4a7f8dbd9d33eaf69645087f06c/cryptography-47.0.0-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9af828c0d5a65c70ec729cd7495a4bf1a67ecb66417b8f02ff125ab8a6326a74", size = 5225777, upload-time = "2026-04-24T19:54:15.18Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/b8/ac57107ef32749d2b244e36069bb688792a363aaaa3acc9e3cf84c130315/cryptography-47.0.0-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:256d07c78a04d6b276f5df935a9923275f53bd1522f214447fdf365494e2d515", size = 4688771, upload-time = "2026-04-24T19:54:17.835Z" },
+    { url = "https://files.pythonhosted.org/packages/56/fc/9f1de22ff8be99d991f240a46863c52d475404c408886c5a38d2b5c3bb26/cryptography-47.0.0-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:5d0e362ff51041b0c0d219cc7d6924d7b8996f57ce5712bdcef71eb3c65a59cc", size = 4270753, upload-time = "2026-04-24T19:54:19.963Z" },
+    { url = "https://files.pythonhosted.org/packages/00/68/d70c852797aa68e8e48d12e5a87170c43f67bb4a59403627259dd57d15de/cryptography-47.0.0-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:1581aef4219f7ca2849d0250edaa3866212fb74bf5667284f46aa92f9e65c1ca", size = 4642911, upload-time = "2026-04-24T19:54:21.818Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/51/661cbee74f594c5d97ff82d34f10d5551c085ca4668645f4606ebd22bd5d/cryptography-47.0.0-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:a49a3eb5341b9503fa3000a9a0db033161db90d47285291f53c2a9d2cd1b7f76", size = 5181411, upload-time = "2026-04-24T19:54:24.376Z" },
+    { url = "https://files.pythonhosted.org/packages/94/87/f2b6c374a82cf076cfa1416992ac8e8ec94d79facc37aec87c1a5cb72352/cryptography-47.0.0-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2207a498b03275d0051589e326b79d4cf59985c99031b05bb292ac52631c37fe", size = 4688262, upload-time = "2026-04-24T19:54:26.946Z" },
+    { url = "https://files.pythonhosted.org/packages/14/e2/8b7462f4acf21ec509616f0245018bb197194ab0b65c2ea21a0bdd53c0eb/cryptography-47.0.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7a02675e2fabd0c0fc04c868b8781863cbf1967691543c22f5470500ff840b31", size = 4775506, upload-time = "2026-04-24T19:54:28.926Z" },
+    { url = "https://files.pythonhosted.org/packages/70/75/158e494e4c08dc05e039da5bb48553826bd26c23930cf8d3cd5f21fa8921/cryptography-47.0.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:80887c5cbd1774683cb126f0ab4184567f080071d5acf62205acb354b4b753b7", size = 4912060, upload-time = "2026-04-24T19:54:30.869Z" },
+    { url = "https://files.pythonhosted.org/packages/06/bd/0a9d3edbf5eadbac926d7b9b3cd0c4be584eeeae4a003d24d9eda4affbbd/cryptography-47.0.0-cp38-abi3-win32.whl", hash = "sha256:ed67ea4e0cfb5faa5bc7ecb6e2b8838f3807a03758eec239d6c21c8769355310", size = 3248487, upload-time = "2026-04-24T19:54:33.494Z" },
+    { url = "https://files.pythonhosted.org/packages/60/80/5681af756d0da3a599b7bdb586fac5a1540f1bcefd2717a20e611ddade45/cryptography-47.0.0-cp38-abi3-win_amd64.whl", hash = "sha256:835d2d7f47cdc53b3224e90810fb1d36ca94ea29cc1801fb4c1bc43876735769", size = 3755737, upload-time = "2026-04-24T19:54:35.408Z" },
+]
+
+[[package]]
+name = "docker"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/9b/4a2ea29aeba62471211598dac5d96825bb49348fa07e906ea930394a83ce/docker-7.1.0.tar.gz", hash = "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c", size = 117834, upload-time = "2024-05-23T11:13:57.216Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/26/57c6fb270950d476074c087527a558ccb6f4436657314bfb6cdf484114c4/docker-7.1.0-py3-none-any.whl", hash = "sha256:c96b93b7f0a746f9e77d325bcfb87422a3d8bd4f03136ae8a85b37f1898d5fc0", size = 147774, upload-time = "2024-05-23T11:13:55.01Z" },
+]
+
+[[package]]
+name = "document-db-mcp"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "asyncpg" },
+    { name = "fastapi" },
+    { name = "mcp" },
+    { name = "psycopg", extra = ["binary"] },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "uvicorn", extra = ["standard"] },
+    { name = "yoyo-migrations" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "httpx" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "testcontainers" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "asyncpg", specifier = ">=0.31.0" },
+    { name = "fastapi", specifier = ">=0.120.0" },
+    { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.28.0" },
+    { name = "mcp", specifier = ">=1.27.0" },
+    { name = "psycopg", extras = ["binary"], specifier = ">=3.2.0" },
+    { name = "pydantic", specifier = ">=2.13.3" },
+    { name = "pydantic-settings", specifier = ">=2.14.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.3.0" },
+    { name = "testcontainers", extras = ["postgres"], marker = "extra == 'dev'", specifier = ">=4.14.2" },
+    { name = "uvicorn", extras = ["standard"], specifier = ">=0.32.0" },
+    { name = "yoyo-migrations", specifier = ">=9.0.0" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "fastapi"
+version = "0.136.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/45/c130091c2dfa061bbfe3150f2a5091ef1adf149f2a8d2ae769ecaf6e99a2/fastapi-0.136.1.tar.gz", hash = "sha256:7af665ad7acfa0a3baf8983d393b6b471b9da10ede59c60045f49fbc89a0fa7f", size = 397448, upload-time = "2026-04-23T16:49:44.046Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/ff/2e4eca3ade2c22fe1dea7043b8ee9dabe47753349eb1b56a202de8af6349/fastapi-0.136.1-py3-none-any.whl", hash = "sha256:a6e9d7eeada96c93a4d69cb03836b44fa34e2854accb7244a1ece36cd4781c3f", size = 117683, upload-time = "2026-04-23T16:49:42.437Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httptools"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/46/120a669232c7bdedb9d52d4aeae7e6c7dfe151e99dc70802e2fc7a5e1993/httptools-0.7.1.tar.gz", hash = "sha256:abd72556974f8e7c74a259655924a717a2365b236c882c3f6f8a45fe94703ac9", size = 258961, upload-time = "2025-10-10T03:55:08.559Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/8f/c77b1fcbfd262d422f12da02feb0d218fa228d52485b77b953832105bb90/httptools-0.7.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:6babce6cfa2a99545c60bfef8bee0cc0545413cb0018f617c8059a30ad985de3", size = 202889, upload-time = "2025-10-10T03:54:47.089Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/1a/22887f53602feaa066354867bc49a68fc295c2293433177ee90870a7d517/httptools-0.7.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:601b7628de7504077dd3dcb3791c6b8694bbd967148a6d1f01806509254fb1ca", size = 108180, upload-time = "2025-10-10T03:54:48.052Z" },
+    { url = "https://files.pythonhosted.org/packages/32/6a/6aaa91937f0010d288d3d124ca2946d48d60c3a5ee7ca62afe870e3ea011/httptools-0.7.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:04c6c0e6c5fb0739c5b8a9eb046d298650a0ff38cf42537fc372b28dc7e4472c", size = 478596, upload-time = "2025-10-10T03:54:48.919Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/70/023d7ce117993107be88d2cbca566a7c1323ccbaf0af7eabf2064fe356f6/httptools-0.7.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:69d4f9705c405ae3ee83d6a12283dc9feba8cc6aaec671b412917e644ab4fa66", size = 473268, upload-time = "2025-10-10T03:54:49.993Z" },
+    { url = "https://files.pythonhosted.org/packages/32/4d/9dd616c38da088e3f436e9a616e1d0cc66544b8cdac405cc4e81c8679fc7/httptools-0.7.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:44c8f4347d4b31269c8a9205d8a5ee2df5322b09bbbd30f8f862185bb6b05346", size = 455517, upload-time = "2025-10-10T03:54:51.066Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/3a/a6c595c310b7df958e739aae88724e24f9246a514d909547778d776799be/httptools-0.7.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:465275d76db4d554918aba40bf1cbebe324670f3dfc979eaffaa5d108e2ed650", size = 458337, upload-time = "2025-10-10T03:54:52.196Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/82/88e8d6d2c51edc1cc391b6e044c6c435b6aebe97b1abc33db1b0b24cd582/httptools-0.7.1-cp313-cp313-win_amd64.whl", hash = "sha256:322d00c2068d125bd570f7bf78b2d367dad02b919d8581d7476d8b75b294e3e6", size = 85743, upload-time = "2025-10-10T03:54:53.448Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "httpx-sse"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+]
+
+[[package]]
+name = "importlib-metadata"
+version = "9.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/3d/2d244233ac4f76e38533cfcb2991c9eb4c7bf688ae0a036d30725b8faafe/importlib_metadata-9.0.0-py3-none-any.whl", hash = "sha256:2d21d1cc5a017bd0559e36150c21c830ab1dc304dedd1b7ea85d20f45ef3edd7", size = 27789, upload-time = "2026-03-20T06:42:55.665Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
+name = "mcp"
+version = "1.27.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "jsonschema" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/eb/c0cfc62075dc6e1ec1c64d352ae09ac051d9334311ed226f1f425312848a/mcp-1.27.0.tar.gz", hash = "sha256:d3dc35a7eec0d458c1da4976a48f982097ddaab87e278c5511d5a4a56e852b83", size = 607509, upload-time = "2026-04-02T14:48:08.88Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/46/f6b4ad632c67ef35209a66127e4bddc95759649dd595f71f13fba11bdf9a/mcp-1.27.0-py3-none-any.whl", hash = "sha256:5ce1fa81614958e267b21fb2aa34e0aea8e2c6ede60d52aba45fd47246b4d741", size = 215967, upload-time = "2026-04-02T14:48:07.24Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "psycopg"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/2f/cb91e5502ec9de1de6f1b76cfbf69531932725361168bb06963620c77e2e/psycopg-3.3.4.tar.gz", hash = "sha256:e21207764952cff81b6b8bdacad9a3939f2793367fdac2987b3aac36a651b5bc", size = 165799, upload-time = "2026-05-01T23:31:55.179Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/e0/7b3dee031daae7743609ce3c746565d4a3ed7c2c186479eb48e34e838c64/psycopg-3.3.4-py3-none-any.whl", hash = "sha256:b6bbc25ccf05c8fad3b061d9db2ef0909a555171b84b07f29458a447253d679a", size = 213001, upload-time = "2026-05-01T23:20:50.816Z" },
+]
+
+[package.optional-dependencies]
+binary = [
+    { name = "psycopg-binary", marker = "implementation_name != 'pypy'" },
+]
+
+[[package]]
+name = "psycopg-binary"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/43/13e9c406fbbf354580476e248a16b64802a376873ebe6339e30bb655572d/psycopg_binary-3.3.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:fbd1d4ed566895ad2d3bf4ddfd8bae90026930ddf29df3b9d91d32c8c47866a7", size = 4590377, upload-time = "2026-05-01T23:29:18.782Z" },
+    { url = "https://files.pythonhosted.org/packages/22/be/2923cd7c3683e7afdecf4f10796a18de02f5c5ddc0969aa2ad0a8cdd3bbd/psycopg_binary-3.3.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:75a9067e236f9b9ae3535b66fe99bddb33d39c0de10112e49b9ab11eee53dc31", size = 4669023, upload-time = "2026-05-01T23:29:25.884Z" },
+    { url = "https://files.pythonhosted.org/packages/96/a0/2c913d6fe13d6a8bd13597d36739bf47af063ad9399e402cfecab16f3c1e/psycopg_binary-3.3.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:b56b603ebcea8aa10b46228b8410ba7f13e7c2ee54389d4d9be0927fd8ce2a70", size = 5467423, upload-time = "2026-05-01T23:29:33.416Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/38/205d10bc1ad0df4a21c5c51659126bd3ea0ef98fcad1e852f78c249bb9c3/psycopg_binary-3.3.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c677c4ad433cb7150c8cd304a0769ae3bcfbe5ea0676eb53faa7b1443b16d0d3", size = 5151137, upload-time = "2026-05-01T23:29:42.013Z" },
+    { url = "https://files.pythonhosted.org/packages/36/fc/f0381ddcd45eff3bb70dbca6823a996048d7f507b2ec3fc92c6fabc0fe87/psycopg_binary-3.3.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:26df2717e59c0473e4465a97dfb1b7afebaa479277870fd5784d1436470db47c", size = 6736671, upload-time = "2026-05-01T23:29:51.626Z" },
+    { url = "https://files.pythonhosted.org/packages/95/40/fa545ae152c24327651e5624e4902121e808270be36c10b12e9939be09bc/psycopg_binary-3.3.4-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1dc1f79fd16bb1f3f4421417a514607539f17804d95c7ed617265369d1981cae", size = 4979601, upload-time = "2026-05-01T23:29:56.961Z" },
+    { url = "https://files.pythonhosted.org/packages/86/e4/2f8a47ee97f90cd2b933d0463081d35631ff419de2b8c984a5f369857de0/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:136f199a407b5348b9b857c504aff60c77622a28482e7195839ce1b51238c4cc", size = 4510513, upload-time = "2026-05-01T23:30:07.243Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/0e/94e842ff4a7f98ed162580ca2e8b8864b28c1e0350f2443f8ee47f821167/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:b6f5a29e9c775b9f12a1a717aa7a2c80f9e1db6f27ba44a5b59c80ac61d2ffcf", size = 4187243, upload-time = "2026-05-01T23:30:15.352Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/83/fc6c174b672e29b7de996ea77b6cbddf46c891751c3355f6974292baa6b4/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:ee17a2cf4943cde261adfad1bbc5bf38d6b3776d7afff74c7cabcbeaeb08c260", size = 3927347, upload-time = "2026-05-01T23:30:21.186Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/65/768364d4a97a15b1a7f47ba52688c1686f22941d8332a8398cefc468e25f/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5c4ab71be17bdca30cb34c34c4e1496e2f5d6f20c199c12bad226070b22ef9bf", size = 4236393, upload-time = "2026-05-01T23:30:26.211Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/3b/218efbc9e645becd80cdf651acda05f85cfe546b7a9c0458c7cbc8fe1f74/psycopg_binary-3.3.4-cp313-cp313-win_amd64.whl", hash = "sha256:dbfdb9b6cc79f31104a7b162a2b921b765fcc62af6c00540a167a8de47e4ed38", size = 3564592, upload-time = "2026-05-01T23:30:31.764Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.13.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/e4/40d09941a2cebcb20609b86a559817d5b9291c49dd6f8c87e5feffbe703a/pydantic-2.13.3.tar.gz", hash = "sha256:af09e9d1d09f4e7fe37145c1f577e1d61ceb9a41924bf0094a36506285d0a84d", size = 844068, upload-time = "2026-04-20T14:46:43.632Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/0a/fd7d723f8f8153418fb40cf9c940e82004fce7e987026b08a68a36dd3fe7/pydantic-2.13.3-py3-none-any.whl", hash = "sha256:6db14ac8dfc9a1e57f87ea2c0de670c251240f43cb0c30a5130e9720dc612927", size = 471981, upload-time = "2026-04-20T14:46:41.402Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2a/ef/f7abb56c49382a246fd2ce9c799691e3c3e7175ec74b14d99e798bcddb1a/pydantic_core-2.46.3.tar.gz", hash = "sha256:41c178f65b8c29807239d47e6050262eb6bf84eb695e41101e62e38df4a5bc2c", size = 471412, upload-time = "2026-04-20T14:40:56.672Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/3c/9b5e8eb9821936d065439c3b0fb1490ffa64163bfe7e1595985a47896073/pydantic_core-2.46.3-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:12bc98de041458b80c86c56b24df1d23832f3e166cbaff011f25d187f5c62c37", size = 2102109, upload-time = "2026-04-20T14:41:24.219Z" },
+    { url = "https://files.pythonhosted.org/packages/91/97/1c41d1f5a19f241d8069f1e249853bcce378cdb76eec8ab636d7bc426280/pydantic_core-2.46.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:85348b8f89d2c3508b65b16c3c33a4da22b8215138d8b996912bb1532868885f", size = 1951820, upload-time = "2026-04-20T14:42:14.236Z" },
+    { url = "https://files.pythonhosted.org/packages/30/b4/d03a7ae14571bc2b6b3c7b122441154720619afe9a336fa3a95434df5e2f/pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1105677a6df914b1fb71a81b96c8cce7726857e1717d86001f29be06a25ee6f8", size = 1977785, upload-time = "2026-04-20T14:42:31.648Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/0c/4086f808834b59e3c8f1aa26df8f4b6d998cdcf354a143d18ef41529d1fe/pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:87082cd65669a33adeba5470769e9704c7cf026cc30afb9cc77fd865578ebaad", size = 2062761, upload-time = "2026-04-20T14:40:37.093Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/71/a649be5a5064c2df0db06e0a512c2281134ed2fcc981f52a657936a7527c/pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:60e5f66e12c4f5212d08522963380eaaeac5ebd795826cfd19b2dfb0c7a52b9c", size = 2232989, upload-time = "2026-04-20T14:42:59.254Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/7756e75763e810b3a710f4724441d1ecc5883b94aacb07ca71c5fb5cfb69/pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b6cdf19bf84128d5e7c37e8a73a0c5c10d51103a650ac585d42dd6ae233f2b7f", size = 2303975, upload-time = "2026-04-20T14:41:32.287Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/35/68a762e0c1e31f35fa0dac733cbd9f5b118042853698de9509c8e5bf128b/pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:031bb17f4885a43773c8c763089499f242aee2ea85cf17154168775dccdecf35", size = 2095325, upload-time = "2026-04-20T14:42:47.685Z" },
+    { url = "https://files.pythonhosted.org/packages/77/bf/1bf8c9a8e91836c926eae5e3e51dce009bf495a60ca56060689d3df3f340/pydantic_core-2.46.3-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:bcf2a8b2982a6673693eae7348ef3d8cf3979c1d63b54fca7c397a635cc68687", size = 2133368, upload-time = "2026-04-20T14:41:22.766Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/50/87d818d6bab915984995157ceb2380f5aac4e563dddbed6b56f0ed057aba/pydantic_core-2.46.3-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:28e8cf2f52d72ced402a137145923a762cbb5081e48b34312f7a0c8f55928ec3", size = 2173908, upload-time = "2026-04-20T14:42:52.044Z" },
+    { url = "https://files.pythonhosted.org/packages/91/88/a311fb306d0bd6185db41fa14ae888fb81d0baf648a761ae760d30819d33/pydantic_core-2.46.3-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:17eaface65d9fc5abb940003020309c1bf7a211f5f608d7870297c367e6f9022", size = 2186422, upload-time = "2026-04-20T14:43:29.55Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/79/28fd0d81508525ab2054fef7c77a638c8b5b0afcbbaeee493cf7c3fef7e1/pydantic_core-2.46.3-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:93fd339f23408a07e98950a89644f92c54d8729719a40b30c0a30bb9ebc55d23", size = 2332709, upload-time = "2026-04-20T14:42:16.134Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/21/795bf5fe5c0f379308b8ef19c50dedab2e7711dbc8d0c2acf08f1c7daa05/pydantic_core-2.46.3-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:23cbdb3aaa74dfe0837975dbf69b469753bbde8eacace524519ffdb6b6e89eb7", size = 2372428, upload-time = "2026-04-20T14:41:10.974Z" },
+    { url = "https://files.pythonhosted.org/packages/45/b3/ed14c659cbe7605e3ef063077680a64680aec81eb1a04763a05190d49b7f/pydantic_core-2.46.3-cp313-cp313-win32.whl", hash = "sha256:610eda2e3838f401105e6326ca304f5da1e15393ae25dacae5c5c63f2c275b13", size = 1965601, upload-time = "2026-04-20T14:41:42.128Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/bb/adb70d9a762ddd002d723fbf1bd492244d37da41e3af7b74ad212609027e/pydantic_core-2.46.3-cp313-cp313-win_amd64.whl", hash = "sha256:68cc7866ed863db34351294187f9b729964c371ba33e31c26f478471c52e1ed0", size = 2071517, upload-time = "2026-04-20T14:43:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/52/eb/66faefabebfe68bd7788339c9c9127231e680b11906368c67ce112fdb47f/pydantic_core-2.46.3-cp313-cp313-win_arm64.whl", hash = "sha256:f64b5537ac62b231572879cd08ec05600308636a5d63bcbdb15063a466977bec", size = 2035802, upload-time = "2026-04-20T14:43:38.507Z" },
+]
+
+[[package]]
+name = "pydantic-settings"
+version = "2.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/98/c8345dccdc31de4228c039a98f6467a941e39558da41c1744fbe29fa5666/pydantic_settings-2.14.0.tar.gz", hash = "sha256:24285fd4b0e0c06507dd9fdfd331ee23794305352aaec8fc4eb92d4047aeb67d", size = 235709, upload-time = "2026-04-20T13:37:40.293Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/dd/bebff3040138f00ae8a102d426b27349b9a49acc310fcae7f92112d867e3/pydantic_settings-2.14.0-py3-none-any.whl", hash = "sha256:fc8d5d692eb7092e43c8647c1c35a3ecd00e040fcf02ed86f4cb5458ca62182e", size = 60940, upload-time = "2026-04-20T13:37:38.586Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.27"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/9b/f23807317a113dc36e74e75eb265a02dd1a4d9082abc3c1064acd22997c4/python_multipart-0.0.27.tar.gz", hash = "sha256:9870a6a8c5a20a5bf4f07c017bd1489006ff8836cff097b6933355ee2b49b602", size = 44043, upload-time = "2026-04-27T10:51:26.649Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/78/4126abcbdbd3c559d43e0db7f7b9173fc6befe45d39a2856cc0b8ec2a5a6/python_multipart-0.0.27-py3-none-any.whl", hash = "sha256:6fccfad17a27334bd0193681b369f476eda3409f17381a2d65aa7df3f7275645", size = 29254, upload-time = "2026-04-27T10:51:24.997Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "311"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/be/3fd5de0979fcb3994bfee0d65ed8ca9506a8a1260651b86174f6a86f52b3/pywin32-311-cp313-cp313-win32.whl", hash = "sha256:f95ba5a847cba10dd8c4d8fefa9f2a6cf283b8b88ed6178fa8a6c1ab16054d0d", size = 8705700, upload-time = "2025-07-14T20:13:26.471Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/28/e0a1909523c6890208295a29e05c2adb2126364e289826c0a8bc7297bd5c/pywin32-311-cp313-cp313-win_amd64.whl", hash = "sha256:718a38f7e5b058e76aee1c56ddd06908116d35147e133427e59a3983f703a20d", size = 9494700, upload-time = "2025-07-14T20:13:28.243Z" },
+    { url = "https://files.pythonhosted.org/packages/04/bf/90339ac0f55726dce7d794e6d79a18a91265bdf3aa70b6b9ca52f35e022a/pywin32-311-cp313-cp313-win_arm64.whl", hash = "sha256:7b4075d959648406202d92a2310cb990fea19b535c7f4a78d3f5e10b926eeb8a", size = 8709318, upload-time = "2025-07-14T20:13:30.348Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+]
+
+[[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.33.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "0.30.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/af/3f2f423103f1113b36230496629986e0ef7e199d2aa8392452b484b38ced/rpds_py-0.30.0.tar.gz", hash = "sha256:dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84", size = 69469, upload-time = "2025-11-30T20:24:38.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ed/dc/d61221eb88ff410de3c49143407f6f3147acf2538c86f2ab7ce65ae7d5f9/rpds_py-0.30.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:f83424d738204d9770830d35290ff3273fbb02b41f919870479fab14b9d303b2", size = 374887, upload-time = "2025-11-30T20:22:41.812Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/32/55fb50ae104061dbc564ef15cc43c013dc4a9f4527a1f4d99baddf56fe5f/rpds_py-0.30.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e7536cd91353c5273434b4e003cbda89034d67e7710eab8761fd918ec6c69cf8", size = 358904, upload-time = "2025-11-30T20:22:43.479Z" },
+    { url = "https://files.pythonhosted.org/packages/58/70/faed8186300e3b9bdd138d0273109784eea2396c68458ed580f885dfe7ad/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2771c6c15973347f50fece41fc447c054b7ac2ae0502388ce3b6738cd366e3d4", size = 389945, upload-time = "2025-11-30T20:22:44.819Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/a8/073cac3ed2c6387df38f71296d002ab43496a96b92c823e76f46b8af0543/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0a59119fc6e3f460315fe9d08149f8102aa322299deaa5cab5b40092345c2136", size = 407783, upload-time = "2025-11-30T20:22:46.103Z" },
+    { url = "https://files.pythonhosted.org/packages/77/57/5999eb8c58671f1c11eba084115e77a8899d6e694d2a18f69f0ba471ec8b/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:76fec018282b4ead0364022e3c54b60bf368b9d926877957a8624b58419169b7", size = 515021, upload-time = "2025-11-30T20:22:47.458Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/af/5ab4833eadc36c0a8ed2bc5c0de0493c04f6c06de223170bd0798ff98ced/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:692bef75a5525db97318e8cd061542b5a79812d711ea03dbc1f6f8dbb0c5f0d2", size = 414589, upload-time = "2025-11-30T20:22:48.872Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/de/f7192e12b21b9e9a68a6d0f249b4af3fdcdff8418be0767a627564afa1f1/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9027da1ce107104c50c81383cae773ef5c24d296dd11c99e2629dbd7967a20c6", size = 394025, upload-time = "2025-11-30T20:22:50.196Z" },
+    { url = "https://files.pythonhosted.org/packages/91/c4/fc70cd0249496493500e7cc2de87504f5aa6509de1e88623431fec76d4b6/rpds_py-0.30.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:9cf69cdda1f5968a30a359aba2f7f9aa648a9ce4b580d6826437f2b291cfc86e", size = 408895, upload-time = "2025-11-30T20:22:51.87Z" },
+    { url = "https://files.pythonhosted.org/packages/58/95/d9275b05ab96556fefff73a385813eb66032e4c99f411d0795372d9abcea/rpds_py-0.30.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a4796a717bf12b9da9d3ad002519a86063dcac8988b030e405704ef7d74d2d9d", size = 422799, upload-time = "2025-11-30T20:22:53.341Z" },
+    { url = "https://files.pythonhosted.org/packages/06/c1/3088fc04b6624eb12a57eb814f0d4997a44b0d208d6cace713033ff1a6ba/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5d4c2aa7c50ad4728a094ebd5eb46c452e9cb7edbfdb18f9e1221f597a73e1e7", size = 572731, upload-time = "2025-11-30T20:22:54.778Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/42/c612a833183b39774e8ac8fecae81263a68b9583ee343db33ab571a7ce55/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba81a9203d07805435eb06f536d95a266c21e5b2dfbf6517748ca40c98d19e31", size = 599027, upload-time = "2025-11-30T20:22:56.212Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/60/525a50f45b01d70005403ae0e25f43c0384369ad24ffe46e8d9068b50086/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:945dccface01af02675628334f7cf49c2af4c1c904748efc5cf7bbdf0b579f95", size = 563020, upload-time = "2025-11-30T20:22:58.2Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/5d/47c4655e9bcd5ca907148535c10e7d489044243cc9941c16ed7cd53be91d/rpds_py-0.30.0-cp313-cp313-win32.whl", hash = "sha256:b40fb160a2db369a194cb27943582b38f79fc4887291417685f3ad693c5a1d5d", size = 223139, upload-time = "2025-11-30T20:23:00.209Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/e1/485132437d20aa4d3e1d8b3fb5a5e65aa8139f1e097080c2a8443201742c/rpds_py-0.30.0-cp313-cp313-win_amd64.whl", hash = "sha256:806f36b1b605e2d6a72716f321f20036b9489d29c51c91f4dd29a3e3afb73b15", size = 240224, upload-time = "2025-11-30T20:23:02.008Z" },
+    { url = "https://files.pythonhosted.org/packages/24/95/ffd128ed1146a153d928617b0ef673960130be0009c77d8fbf0abe306713/rpds_py-0.30.0-cp313-cp313-win_arm64.whl", hash = "sha256:d96c2086587c7c30d44f31f42eae4eac89b60dabbac18c7669be3700f13c3ce1", size = 230645, upload-time = "2025-11-30T20:23:03.43Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/1b/b10de890a0def2a319a2626334a7f0ae388215eb60914dbac8a3bae54435/rpds_py-0.30.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:eb0b93f2e5c2189ee831ee43f156ed34e2a89a78a66b98cadad955972548be5a", size = 364443, upload-time = "2025-11-30T20:23:04.878Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/bf/27e39f5971dc4f305a4fb9c672ca06f290f7c4e261c568f3dea16a410d47/rpds_py-0.30.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:922e10f31f303c7c920da8981051ff6d8c1a56207dbdf330d9047f6d30b70e5e", size = 353375, upload-time = "2025-11-30T20:23:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/40/58/442ada3bba6e8e6615fc00483135c14a7538d2ffac30e2d933ccf6852232/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cdc62c8286ba9bf7f47befdcea13ea0e26bf294bda99758fd90535cbaf408000", size = 383850, upload-time = "2025-11-30T20:23:07.825Z" },
+    { url = "https://files.pythonhosted.org/packages/14/14/f59b0127409a33c6ef6f5c1ebd5ad8e32d7861c9c7adfa9a624fc3889f6c/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:47f9a91efc418b54fb8190a6b4aa7813a23fb79c51f4bb84e418f5476c38b8db", size = 392812, upload-time = "2025-11-30T20:23:09.228Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/66/e0be3e162ac299b3a22527e8913767d869e6cc75c46bd844aa43fb81ab62/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1f3587eb9b17f3789ad50824084fa6f81921bbf9a795826570bda82cb3ed91f2", size = 517841, upload-time = "2025-11-30T20:23:11.186Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/55/fa3b9cf31d0c963ecf1ba777f7cf4b2a2c976795ac430d24a1f43d25a6ba/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:39c02563fc592411c2c61d26b6c5fe1e51eaa44a75aa2c8735ca88b0d9599daa", size = 408149, upload-time = "2025-11-30T20:23:12.864Z" },
+    { url = "https://files.pythonhosted.org/packages/60/ca/780cf3b1a32b18c0f05c441958d3758f02544f1d613abf9488cd78876378/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51a1234d8febafdfd33a42d97da7a43f5dcb120c1060e352a3fbc0c6d36e2083", size = 383843, upload-time = "2025-11-30T20:23:14.638Z" },
+    { url = "https://files.pythonhosted.org/packages/82/86/d5f2e04f2aa6247c613da0c1dd87fcd08fa17107e858193566048a1e2f0a/rpds_py-0.30.0-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:eb2c4071ab598733724c08221091e8d80e89064cd472819285a9ab0f24bcedb9", size = 396507, upload-time = "2025-11-30T20:23:16.105Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/9a/453255d2f769fe44e07ea9785c8347edaf867f7026872e76c1ad9f7bed92/rpds_py-0.30.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6bdfdb946967d816e6adf9a3d8201bfad269c67efe6cefd7093ef959683c8de0", size = 414949, upload-time = "2025-11-30T20:23:17.539Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/31/622a86cdc0c45d6df0e9ccb6becdba5074735e7033c20e401a6d9d0e2ca0/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c77afbd5f5250bf27bf516c7c4a016813eb2d3e116139aed0096940c5982da94", size = 565790, upload-time = "2025-11-30T20:23:19.029Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/5d/15bbf0fb4a3f58a3b1c67855ec1efcc4ceaef4e86644665fff03e1b66d8d/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:61046904275472a76c8c90c9ccee9013d70a6d0f73eecefd38c1ae7c39045a08", size = 590217, upload-time = "2025-11-30T20:23:20.885Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/61/21b8c41f68e60c8cc3b2e25644f0e3681926020f11d06ab0b78e3c6bbff1/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4c5f36a861bc4b7da6516dbdf302c55313afa09b81931e8280361a4f6c9a2d27", size = 555806, upload-time = "2025-11-30T20:23:22.488Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/39/7e067bb06c31de48de3eb200f9fc7c58982a4d3db44b07e73963e10d3be9/rpds_py-0.30.0-cp313-cp313t-win32.whl", hash = "sha256:3d4a69de7a3e50ffc214ae16d79d8fbb0922972da0356dcf4d0fdca2878559c6", size = 211341, upload-time = "2025-11-30T20:23:24.449Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/4d/222ef0b46443cf4cf46764d9c630f3fe4abaa7245be9417e56e9f52b8f65/rpds_py-0.30.0-cp313-cp313t-win_amd64.whl", hash = "sha256:f14fc5df50a716f7ece6a80b6c78bb35ea2ca47c499e422aa4463455dd96d56d", size = 225768, upload-time = "2025-11-30T20:23:25.908Z" },
+]
+
+[[package]]
+name = "sqlparse"
+version = "0.5.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/90/76/437d71068094df0726366574cf3432a4ed754217b436eb7429415cf2d480/sqlparse-0.5.5.tar.gz", hash = "sha256:e20d4a9b0b8585fdf63b10d30066c7c94c5d7a7ec47c889a2d83a3caa93ff28e", size = 120815, upload-time = "2025-12-19T07:17:45.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/4b/359f28a903c13438ef59ebeee215fb25da53066db67b305c125f1c6d2a25/sqlparse-0.5.5-py3-none-any.whl", hash = "sha256:12a08b3bf3eec877c519589833aed092e2444e68240a3577e8e26148acc7b1ba", size = 46138, upload-time = "2025-12-19T07:17:46.573Z" },
+]
+
+[[package]]
+name = "sse-starlette"
+version = "3.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e1/9a/f35932a8c0eb6b2287b66fa65a0321df8c84e4e355a659c1841a37c39fdb/sse_starlette-3.4.1.tar.gz", hash = "sha256:f780bebcf6c8997fe514e3bd8e8c648d8284976b391c8bed0bcb1f611632b555", size = 35127, upload-time = "2026-04-26T13:32:32.292Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ff/07/45c21ed03d708c477367305726b89919b020a3a2a01f72aaf5ad941caf35/sse_starlette-3.4.1-py3-none-any.whl", hash = "sha256:6b43cf21f1d574d582a6e1b0cfbde1c94dc86a32a701a7168c99c4475c6bd1d0", size = 16487, upload-time = "2026-04-26T13:32:30.819Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+]
+
+[[package]]
+name = "tabulate"
+version = "0.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/58/8c37dea7bbf769b20d58e7ace7e5edfe65b849442b00ffcdd56be88697c6/tabulate-0.10.0.tar.gz", hash = "sha256:e2cfde8f79420f6deeffdeda9aaec3b6bc5abce947655d17ac662b126e48a60d", size = 91754, upload-time = "2026-03-04T18:55:34.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl", hash = "sha256:f0b0622e567335c8fabaaa659f1b33bcb6ddfe2e496071b743aa113f8774f2d3", size = 39814, upload-time = "2026-03-04T18:55:31.284Z" },
+]
+
+[[package]]
+name = "testcontainers"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docker" },
+    { name = "python-dotenv" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ca/ac/a597c3a0e02b26cbed6dd07df68be1e57684766fd1c381dee9b170a99690/testcontainers-4.14.2.tar.gz", hash = "sha256:1340ccf16fe3acd9389a6c9e1d9ab21d9fe99a8afdf8165f89c3e69c1967d239", size = 166841, upload-time = "2026-03-18T05:19:16.696Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/2d/26b8b30067d94339afee62c3edc9b803a6eb9332f521ba77d8aaab5de873/testcontainers-4.14.2-py3-none-any.whl", hash = "sha256:0d0522c3cd8f8d9627cda41f7a6b51b639fa57bdc492923c045117933c668d68", size = 125712, upload-time = "2026-03-18T05:19:15.29Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.46.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/93/041fca8274050e40e6791f267d82e0e2e27dd165627bd640d3e0e378d877/uvicorn-0.46.0.tar.gz", hash = "sha256:fb9da0926999cc6cb22dc7cd71a94a632f078e6ae47ff683c5c420750fb7413d", size = 88758, upload-time = "2026-04-23T07:16:00.151Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/a3/5b1562db76a5a488274b2332a97199b32d0442aca0ed193697fd47786316/uvicorn-0.46.0-py3-none-any.whl", hash = "sha256:bbebbcbed972d162afca128605223022bedd345b7bc7855ce66deb31487a9048", size = 70926, upload-time = "2026-04-23T07:15:58.355Z" },
+]
+
+[package.optional-dependencies]
+standard = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "httptools" },
+    { name = "python-dotenv" },
+    { name = "pyyaml" },
+    { name = "uvloop", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32'" },
+    { name = "watchfiles" },
+    { name = "websockets" },
+]
+
+[[package]]
+name = "uvloop"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/f0/18d39dbd1971d6d62c4629cc7fa67f74821b0dc1f5a77af43719de7936a7/uvloop-0.22.1.tar.gz", hash = "sha256:6c84bae345b9147082b17371e3dd5d42775bddce91f885499017f4607fdaf39f", size = 2443250, upload-time = "2025-10-16T22:17:19.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/8c/182a2a593195bfd39842ea68ebc084e20c850806117213f5a299dfc513d9/uvloop-0.22.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:561577354eb94200d75aca23fbde86ee11be36b00e52a4eaf8f50fb0c86b7705", size = 1358611, upload-time = "2025-10-16T22:16:36.833Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/14/e301ee96a6dc95224b6f1162cd3312f6d1217be3907b79173b06785f2fe7/uvloop-0.22.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1cdf5192ab3e674ca26da2eada35b288d2fa49fdd0f357a19f0e7c4e7d5077c8", size = 751811, upload-time = "2025-10-16T22:16:38.275Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/02/654426ce265ac19e2980bfd9ea6590ca96a56f10c76e63801a2df01c0486/uvloop-0.22.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6e2ea3d6190a2968f4a14a23019d3b16870dd2190cd69c8180f7c632d21de68d", size = 4288562, upload-time = "2025-10-16T22:16:39.375Z" },
+    { url = "https://files.pythonhosted.org/packages/15/c0/0be24758891ef825f2065cd5db8741aaddabe3e248ee6acc5e8a80f04005/uvloop-0.22.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0530a5fbad9c9e4ee3f2b33b148c6a64d47bbad8000ea63704fa8260f4cf728e", size = 4366890, upload-time = "2025-10-16T22:16:40.547Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/53/8369e5219a5855869bcee5f4d317f6da0e2c669aecf0ef7d371e3d084449/uvloop-0.22.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bc5ef13bbc10b5335792360623cc378d52d7e62c2de64660616478c32cd0598e", size = 4119472, upload-time = "2025-10-16T22:16:41.694Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ba/d69adbe699b768f6b29a5eec7b47dd610bd17a69de51b251126a801369ea/uvloop-0.22.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1f38ec5e3f18c8a10ded09742f7fb8de0108796eb673f30ce7762ce1b8550cad", size = 4239051, upload-time = "2025-10-16T22:16:43.224Z" },
+]
+
+[[package]]
+name = "watchfiles"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c2/c9/8869df9b2a2d6c59d79220a4db37679e74f807c559ffe5265e08b227a210/watchfiles-1.1.1.tar.gz", hash = "sha256:a173cb5c16c4f40ab19cecf48a534c409f7ea983ab8fed0741304a1c0a31b3f2", size = 94440, upload-time = "2025-10-14T15:06:21.08Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/f4/f750b29225fe77139f7ae5de89d4949f5a99f934c65a1f1c0b248f26f747/watchfiles-1.1.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:130e4876309e8686a5e37dba7d5e9bc77e6ed908266996ca26572437a5271e18", size = 404321, upload-time = "2025-10-14T15:05:02.063Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f9/f07a295cde762644aa4c4bb0f88921d2d141af45e735b965fb2e87858328/watchfiles-1.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:5f3bde70f157f84ece3765b42b4a52c6ac1a50334903c6eaf765362f6ccca88a", size = 391783, upload-time = "2025-10-14T15:05:03.052Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/11/fc2502457e0bea39a5c958d86d2cb69e407a4d00b85735ca724bfa6e0d1a/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:14e0b1fe858430fc0251737ef3824c54027bedb8c37c38114488b8e131cf8219", size = 449279, upload-time = "2025-10-14T15:05:04.004Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/1f/d66bc15ea0b728df3ed96a539c777acfcad0eb78555ad9efcaa1274688f0/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f27db948078f3823a6bb3b465180db8ebecf26dd5dae6f6180bd87383b6b4428", size = 459405, upload-time = "2025-10-14T15:05:04.942Z" },
+    { url = "https://files.pythonhosted.org/packages/be/90/9f4a65c0aec3ccf032703e6db02d89a157462fbb2cf20dd415128251cac0/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:059098c3a429f62fc98e8ec62b982230ef2c8df68c79e826e37b895bc359a9c0", size = 488976, upload-time = "2025-10-14T15:05:05.905Z" },
+    { url = "https://files.pythonhosted.org/packages/37/57/ee347af605d867f712be7029bb94c8c071732a4b44792e3176fa3c612d39/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bfb5862016acc9b869bb57284e6cb35fdf8e22fe59f7548858e2f971d045f150", size = 595506, upload-time = "2025-10-14T15:05:06.906Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/78/cc5ab0b86c122047f75e8fc471c67a04dee395daf847d3e59381996c8707/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:319b27255aacd9923b8a276bb14d21a5f7ff82564c744235fc5eae58d95422ae", size = 474936, upload-time = "2025-10-14T15:05:07.906Z" },
+    { url = "https://files.pythonhosted.org/packages/62/da/def65b170a3815af7bd40a3e7010bf6ab53089ef1b75d05dd5385b87cf08/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c755367e51db90e75b19454b680903631d41f9e3607fbd941d296a020c2d752d", size = 456147, upload-time = "2025-10-14T15:05:09.138Z" },
+    { url = "https://files.pythonhosted.org/packages/57/99/da6573ba71166e82d288d4df0839128004c67d2778d3b566c138695f5c0b/watchfiles-1.1.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:c22c776292a23bfc7237a98f791b9ad3144b02116ff10d820829ce62dff46d0b", size = 630007, upload-time = "2025-10-14T15:05:10.117Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/51/7439c4dd39511368849eb1e53279cd3454b4a4dbace80bab88feeb83c6b5/watchfiles-1.1.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:3a476189be23c3686bc2f4321dd501cb329c0a0469e77b7b534ee10129ae6374", size = 622280, upload-time = "2025-10-14T15:05:11.146Z" },
+    { url = "https://files.pythonhosted.org/packages/95/9c/8ed97d4bba5db6fdcdb2b298d3898f2dd5c20f6b73aee04eabe56c59677e/watchfiles-1.1.1-cp313-cp313-win32.whl", hash = "sha256:bf0a91bfb5574a2f7fc223cf95eeea79abfefa404bf1ea5e339c0c1560ae99a0", size = 272056, upload-time = "2025-10-14T15:05:12.156Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f3/c14e28429f744a260d8ceae18bf58c1d5fa56b50d006a7a9f80e1882cb0d/watchfiles-1.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:52e06553899e11e8074503c8e716d574adeeb7e68913115c4b3653c53f9bae42", size = 288162, upload-time = "2025-10-14T15:05:13.208Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/61/fe0e56c40d5cd29523e398d31153218718c5786b5e636d9ae8ae79453d27/watchfiles-1.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:ac3cc5759570cd02662b15fbcd9d917f7ecd47efe0d6b40474eafd246f91ea18", size = 277909, upload-time = "2025-10-14T15:05:14.49Z" },
+    { url = "https://files.pythonhosted.org/packages/79/42/e0a7d749626f1e28c7108a99fb9bf524b501bbbeb9b261ceecde644d5a07/watchfiles-1.1.1-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:563b116874a9a7ce6f96f87cd0b94f7faf92d08d0021e837796f0a14318ef8da", size = 403389, upload-time = "2025-10-14T15:05:15.777Z" },
+    { url = "https://files.pythonhosted.org/packages/15/49/08732f90ce0fbbc13913f9f215c689cfc9ced345fb1bcd8829a50007cc8d/watchfiles-1.1.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3ad9fe1dae4ab4212d8c91e80b832425e24f421703b5a42ef2e4a1e215aff051", size = 389964, upload-time = "2025-10-14T15:05:16.85Z" },
+    { url = "https://files.pythonhosted.org/packages/27/0d/7c315d4bd5f2538910491a0393c56bf70d333d51bc5b34bee8e68e8cea19/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce70f96a46b894b36eba678f153f052967a0d06d5b5a19b336ab0dbbd029f73e", size = 448114, upload-time = "2025-10-14T15:05:17.876Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/24/9e096de47a4d11bc4df41e9d1e61776393eac4cb6eb11b3e23315b78b2cc/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:cb467c999c2eff23a6417e58d75e5828716f42ed8289fe6b77a7e5a91036ca70", size = 460264, upload-time = "2025-10-14T15:05:18.962Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/0f/e8dea6375f1d3ba5fcb0b3583e2b493e77379834c74fd5a22d66d85d6540/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:836398932192dae4146c8f6f737d74baeac8b70ce14831a239bdb1ca882fc261", size = 487877, upload-time = "2025-10-14T15:05:20.094Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/5b/df24cfc6424a12deb41503b64d42fbea6b8cb357ec62ca84a5a3476f654a/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:743185e7372b7bc7c389e1badcc606931a827112fbbd37f14c537320fca08620", size = 595176, upload-time = "2025-10-14T15:05:21.134Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/b5/853b6757f7347de4e9b37e8cc3289283fb983cba1ab4d2d7144694871d9c/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:afaeff7696e0ad9f02cbb8f56365ff4686ab205fcf9c4c5b6fdfaaa16549dd04", size = 473577, upload-time = "2025-10-14T15:05:22.306Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/f7/0a4467be0a56e80447c8529c9fce5b38eab4f513cb3d9bf82e7392a5696b/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3f7eb7da0eb23aa2ba036d4f616d46906013a68caf61b7fdbe42fc8b25132e77", size = 455425, upload-time = "2025-10-14T15:05:23.348Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/e0/82583485ea00137ddf69bc84a2db88bd92ab4a6e3c405e5fb878ead8d0e7/watchfiles-1.1.1-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:831a62658609f0e5c64178211c942ace999517f5770fe9436be4c2faeba0c0ef", size = 628826, upload-time = "2025-10-14T15:05:24.398Z" },
+    { url = "https://files.pythonhosted.org/packages/28/9a/a785356fccf9fae84c0cc90570f11702ae9571036fb25932f1242c82191c/watchfiles-1.1.1-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:f9a2ae5c91cecc9edd47e041a930490c31c3afb1f5e6d71de3dc671bfaca02bf", size = 622208, upload-time = "2025-10-14T15:05:25.45Z" },
+]
+
+[[package]]
+name = "websockets"
+version = "16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/24/4b2031d72e840ce4c1ccb255f693b15c334757fc50023e4db9537080b8c4/websockets-16.0.tar.gz", hash = "sha256:5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5", size = 179346, upload-time = "2026-01-10T09:23:47.181Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/9c/baa8456050d1c1b08dd0ec7346026668cbc6f145ab4e314d707bb845bf0d/websockets-16.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:878b336ac47938b474c8f982ac2f7266a540adc3fa4ad74ae96fea9823a02cc9", size = 177364, upload-time = "2026-01-10T09:22:59.333Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/0c/8811fc53e9bcff68fe7de2bcbe75116a8d959ac699a3200f4847a8925210/websockets-16.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:52a0fec0e6c8d9a784c2c78276a48a2bdf099e4ccc2a4cad53b27718dbfd0230", size = 175039, upload-time = "2026-01-10T09:23:01.171Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/82/39a5f910cb99ec0b59e482971238c845af9220d3ab9fa76dd9162cda9d62/websockets-16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6578ed5b6981005df1860a56e3617f14a6c307e6a71b4fff8c48fdc50f3ed2c", size = 175323, upload-time = "2026-01-10T09:23:02.341Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/28/0a25ee5342eb5d5f297d992a77e56892ecb65e7854c7898fb7d35e9b33bd/websockets-16.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:95724e638f0f9c350bb1c2b0a7ad0e83d9cc0c9259f3ea94e40d7b02a2179ae5", size = 184975, upload-time = "2026-01-10T09:23:03.756Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/66/27ea52741752f5107c2e41fda05e8395a682a1e11c4e592a809a90c6a506/websockets-16.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0204dc62a89dc9d50d682412c10b3542d748260d743500a85c13cd1ee4bde82", size = 186203, upload-time = "2026-01-10T09:23:05.01Z" },
+    { url = "https://files.pythonhosted.org/packages/37/e5/8e32857371406a757816a2b471939d51c463509be73fa538216ea52b792a/websockets-16.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:52ac480f44d32970d66763115edea932f1c5b1312de36df06d6b219f6741eed8", size = 185653, upload-time = "2026-01-10T09:23:06.301Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/67/f926bac29882894669368dc73f4da900fcdf47955d0a0185d60103df5737/websockets-16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6e5a82b677f8f6f59e8dfc34ec06ca6b5b48bc4fcda346acd093694cc2c24d8f", size = 184920, upload-time = "2026-01-10T09:23:07.492Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a1/3d6ccdcd125b0a42a311bcd15a7f705d688f73b2a22d8cf1c0875d35d34a/websockets-16.0-cp313-cp313-win32.whl", hash = "sha256:abf050a199613f64c886ea10f38b47770a65154dc37181bfaff70c160f45315a", size = 178255, upload-time = "2026-01-10T09:23:09.245Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/ae/90366304d7c2ce80f9b826096a9e9048b4bb760e44d3b873bb272cba696b/websockets-16.0-cp313-cp313-win_amd64.whl", hash = "sha256:3425ac5cf448801335d6fdc7ae1eb22072055417a96cc6b31b3861f455fbc156", size = 178689, upload-time = "2026-01-10T09:23:10.483Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/64/925f213fdcbb9baeb1530449ac71a4d57fc361c053d06bf78d0c5c7cd80c/wrapt-2.1.2.tar.gz", hash = "sha256:3996a67eecc2c68fd47b4e3c564405a5777367adfd9b8abb58387b63ee83b21e", size = 81678, upload-time = "2026-03-06T02:53:25.134Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4c/7a/d936840735c828b38d26a854e85d5338894cda544cb7a85a9d5b8b9c4df7/wrapt-2.1.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:787fd6f4d67befa6fe2abdffcbd3de2d82dfc6fb8a6d850407c53332709d030b", size = 61259, upload-time = "2026-03-06T02:53:41.922Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/88/9a9b9a90ac8ca11c2fdb6a286cb3a1fc7dd774c00ed70929a6434f6bc634/wrapt-2.1.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4bdf26e03e6d0da3f0e9422fd36bcebf7bc0eeb55fdf9c727a09abc6b9fe472e", size = 61851, upload-time = "2026-03-06T02:52:48.672Z" },
+    { url = "https://files.pythonhosted.org/packages/03/a9/5b7d6a16fd6533fed2756900fc8fc923f678179aea62ada6d65c92718c00/wrapt-2.1.2-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:bbac24d879aa22998e87f6b3f481a5216311e7d53c7db87f189a7a0266dafffb", size = 121446, upload-time = "2026-03-06T02:54:14.013Z" },
+    { url = "https://files.pythonhosted.org/packages/45/bb/34c443690c847835cfe9f892be78c533d4f32366ad2888972c094a897e39/wrapt-2.1.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:16997dfb9d67addc2e3f41b62a104341e80cac52f91110dece393923c0ebd5ca", size = 123056, upload-time = "2026-03-06T02:54:10.829Z" },
+    { url = "https://files.pythonhosted.org/packages/93/b9/ff205f391cb708f67f41ea148545f2b53ff543a7ac293b30d178af4d2271/wrapt-2.1.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:162e4e2ba7542da9027821cb6e7c5e068d64f9a10b5f15512ea28e954893a267", size = 117359, upload-time = "2026-03-06T02:53:03.623Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/3d/1ea04d7747825119c3c9a5e0874a40b33594ada92e5649347c457d982805/wrapt-2.1.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f29c827a8d9936ac320746747a016c4bc66ef639f5cd0d32df24f5eacbf9c69f", size = 121479, upload-time = "2026-03-06T02:53:45.844Z" },
+    { url = "https://files.pythonhosted.org/packages/78/cc/ee3a011920c7a023b25e8df26f306b2484a531ab84ca5c96260a73de76c0/wrapt-2.1.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:a9dd9813825f7ecb018c17fd147a01845eb330254dff86d3b5816f20f4d6aaf8", size = 116271, upload-time = "2026-03-06T02:54:46.356Z" },
+    { url = "https://files.pythonhosted.org/packages/98/fd/e5ff7ded41b76d802cf1191288473e850d24ba2e39a6ec540f21ae3b57cb/wrapt-2.1.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6f8dbdd3719e534860d6a78526aafc220e0241f981367018c2875178cf83a413", size = 120573, upload-time = "2026-03-06T02:52:50.163Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c5/242cae3b5b080cd09bacef0591691ba1879739050cc7c801ff35c8886b66/wrapt-2.1.2-cp313-cp313-win32.whl", hash = "sha256:5c35b5d82b16a3bc6e0a04349b606a0582bc29f573786aebe98e0c159bc48db6", size = 58205, upload-time = "2026-03-06T02:53:47.494Z" },
+    { url = "https://files.pythonhosted.org/packages/12/69/c358c61e7a50f290958809b3c61ebe8b3838ea3e070d7aac9814f95a0528/wrapt-2.1.2-cp313-cp313-win_amd64.whl", hash = "sha256:f8bc1c264d8d1cf5b3560a87bbdd31131573eb25f9f9447bb6252b8d4c44a3a1", size = 60452, upload-time = "2026-03-06T02:53:30.038Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/66/c8a6fcfe321295fd8c0ab1bd685b5a01462a9b3aa2f597254462fc2bc975/wrapt-2.1.2-cp313-cp313-win_arm64.whl", hash = "sha256:3beb22f674550d5634642c645aba4c72a2c66fb185ae1aebe1e955fae5a13baf", size = 58842, upload-time = "2026-03-06T02:52:52.114Z" },
+    { url = "https://files.pythonhosted.org/packages/da/55/9c7052c349106e0b3f17ae8db4b23a691a963c334de7f9dbd60f8f74a831/wrapt-2.1.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0fc04bc8664a8bc4c8e00b37b5355cffca2535209fba1abb09ae2b7c76ddf82b", size = 63075, upload-time = "2026-03-06T02:53:19.108Z" },
+    { url = "https://files.pythonhosted.org/packages/09/a8/ce7b4006f7218248dd71b7b2b732d0710845a0e49213b18faef64811ffef/wrapt-2.1.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:a9b9d50c9af998875a1482a038eb05755dfd6fe303a313f6a940bb53a83c3f18", size = 63719, upload-time = "2026-03-06T02:54:33.452Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/e5/2ca472e80b9e2b7a17f106bb8f9df1db11e62101652ce210f66935c6af67/wrapt-2.1.2-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2d3ff4f0024dd224290c0eabf0240f1bfc1f26363431505fb1b0283d3b08f11d", size = 152643, upload-time = "2026-03-06T02:52:42.721Z" },
+    { url = "https://files.pythonhosted.org/packages/36/42/30f0f2cefca9d9cbf6835f544d825064570203c3e70aa873d8ae12e23791/wrapt-2.1.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3278c471f4468ad544a691b31bb856374fbdefb7fee1a152153e64019379f015", size = 158805, upload-time = "2026-03-06T02:54:25.441Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/67/d08672f801f604889dcf58f1a0b424fe3808860ede9e03affc1876b295af/wrapt-2.1.2-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a8914c754d3134a3032601c6984db1c576e6abaf3fc68094bb8ab1379d75ff92", size = 145990, upload-time = "2026-03-06T02:53:57.456Z" },
+    { url = "https://files.pythonhosted.org/packages/68/a7/fd371b02e73babec1de6ade596e8cd9691051058cfdadbfd62a5898f3295/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:ff95d4264e55839be37bafe1536db2ab2de19da6b65f9244f01f332b5286cfbf", size = 155670, upload-time = "2026-03-06T02:54:55.309Z" },
+    { url = "https://files.pythonhosted.org/packages/86/2d/9fe0095dfdb621009f40117dcebf41d7396c2c22dca6eac779f4c007b86c/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:76405518ca4e1b76fbb1b9f686cff93aebae03920cc55ceeec48ff9f719c5f67", size = 144357, upload-time = "2026-03-06T02:54:24.092Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/b6/ec7b4a254abbe4cde9fa15c5d2cca4518f6b07d0f1b77d4ee9655e30280e/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c0be8b5a74c5824e9359b53e7e58bef71a729bacc82e16587db1c4ebc91f7c5a", size = 150269, upload-time = "2026-03-06T02:53:31.268Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/6b/2fabe8ebf148f4ee3c782aae86a795cc68ffe7d432ef550f234025ce0cfa/wrapt-2.1.2-cp313-cp313t-win32.whl", hash = "sha256:f01277d9a5fc1862f26f7626da9cf443bebc0abd2f303f41c5e995b15887dabd", size = 59894, upload-time = "2026-03-06T02:54:15.391Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/fb/9ba66fc2dedc936de5f8073c0217b5d4484e966d87723415cc8262c5d9c2/wrapt-2.1.2-cp313-cp313t-win_amd64.whl", hash = "sha256:84ce8f1c2104d2f6daa912b1b5b039f331febfeee74f8042ad4e04992bd95c8f", size = 63197, upload-time = "2026-03-06T02:54:41.943Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/1c/012d7423c95d0e337117723eb8ecf73c622ce15a97847e84cf3f8f26cd7e/wrapt-2.1.2-cp313-cp313t-win_arm64.whl", hash = "sha256:a93cd767e37faeddbe07d8fc4212d5cba660af59bdb0f6372c93faaa13e6e679", size = 60363, upload-time = "2026-03-06T02:54:48.093Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/c7/8528ac2dfa2c1e6708f647df7ae144ead13f0a31146f43c7264b4942bf12/wrapt-2.1.2-py3-none-any.whl", hash = "sha256:b8fd6fa2b2c4e7621808f8c62e8317f4aae56e59721ad933bac5239d913cf0e8", size = 43993, upload-time = "2026-03-06T02:53:12.905Z" },
+]
+
+[[package]]
+name = "yoyo-migrations"
+version = "9.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-metadata" },
+    { name = "sqlparse" },
+    { name = "tabulate" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8c/5d/9ef7f808ea955eca9f08043c65bdc81a4694e784c978b24ad72022974a97/yoyo_migrations-9.0.0-py3-none-any.whl", hash = "sha256:fc65d3a6d9449c1c54d64ff2ff98e32a27da356057c60e3471010bfb19ede081", size = 49002, upload-time = "2024-08-10T09:43:50.388Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "3.23.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/21/093488dfc7cc8964ded15ab726fad40f25fd3d788fd741cc1c5a17d78ee8/zipp-3.23.1.tar.gz", hash = "sha256:32120e378d32cd9714ad503c1d024619063ec28aad2248dc6672ad13edfa5110", size = 25965, upload-time = "2026-04-13T23:21:46.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/8a/0861bec20485572fbddf3dfba2910e38fe249796cb73ecdeb74e07eeb8d3/zipp-3.23.1-py3-none-any.whl", hash = "sha256:0b3596c50a5c700c9cb40ba8d86d9f2cc4807e9bedb06bcdf7fac85633e444dc", size = 10378, upload-time = "2026-04-13T23:21:45.386Z" },
+]


### PR DESCRIPTION
## Summary

PostgreSQL `dev_team` DB 위에 streamable HTTP MCP 서버. 5 collections (agent_tasks / agent_sessions / agent_items / issues / wiki_pages) 의 thin CRUD 게이트. 본 PR 은 동시에 **모든 향후 MCP 가 따를 공통 패턴** 을 codify (`mcp/CLAUDE.md`) — #35 가 본 패턴의 1호 사례.

추가로 본 PR 에서 결정된 일반 규약을 root CLAUDE.md 에 반영 + 새 신설 자산 패턴 (`agents/{name}/resources/`) + Primary 의 wiki authoring guide.

Closes #35

## 4 commits

| commit | 내용 |
|---|---|
| `361a24a` | **chore: root CLAUDE.md** — 모듈 구조 / 포트 컨벤션 / resources 패턴 |
| `f1f4885` | **docs**: document-db schema + Primary wiki authoring guide |
| `00d87fb` | **feat(mcp)**: document-db MCP 풀 구현 + 컨테이너 + 테스트 |
| `59a5548` | **docs(mcp)**: `mcp/CLAUDE.md` — 모든 MCP 의 공통 골격 / 패턴 규약 |

## 설계 결정

| 항목 | 결정 |
|---|---|
| collection 명명 | `agent_*` (Chronicler 3계층) + `issues` + `wiki_pages` 5종. PRD 는 `wiki_pages.page_type='prd'` 로 통합 |
| 코드 구조 | `schemas/` `repositories/` `tools/` 분리 + `AbstractRepository[T]` ABC. 새 collection = 새 파일 1개씩 (OCP) |
| Migration | yoyo-migrations, MCP 서버 부팅 시 자동 적용. forward / rollback 분리 파일 |
| Concurrency | FIFO 큐 미사용 (사용자 답변 대로 over-engineering). `issues` / `wiki_pages` 만 `version` 컬럼 + optimistic locking |
| Transport | streamable HTTP (MCP spec 2025-06-18) |
| 호스트 포트 | **9100** (root CLAUDE.md 의 새 포트 컨벤션 따름) |
| AI 에이전트 가이드 | `mcp/CLAUDE.md` (모든 MCP 공통) + `mcp/document-db/CLAUDE.md` (모듈 한정) + root CLAUDE.md (프로젝트 일반) — 3 계층 |
| 향후 MCP 작성 표준 | `mcp/CLAUDE.md` 의 §1 (고정 골격) + §2 (backend 변형) + §5 (체크리스트) 따름 |

## 도구 면 (총 29개)

| collection | 5 op | 특수 도구 |
|---|---|---|
| `agent_task` | upsert / get / list / delete / count | – |
| `agent_session` | 5 op | `list_by_task` / `find_by_context` |
| `agent_item` | create / get / list / delete / count (immutable — no upsert) | `list_by_session` |
| `issue` | 5 op (upsert 가 `expected_version` 받음) | – |
| `wiki_page` | 5 op | `get_by_slug` |

## 향후 MCP 패턴화 — `mcp/CLAUDE.md`

본 PR 에 codify 된 골격을 향후 MCP 모두 따름:

- **고정**: 디렉터리 구조 / FastMCP + lifespan + AppContext / 도구 등록 패턴 / 5 op 표준 / streamable HTTP / 포트 대역
- **유동 (backend 따라)**: DB-backed = `repositories/` + `migrations/`; API-client = `adapters/` + factory
- **Reference 구현**: `mcp/document-db/` — 본 PR 의 산출물이 그대로 1호 사례

#36 (IssueTracker MCP, GitHub) / #37 (Wiki MCP, GitHub) / M4 (Graph DB MCP) 가 본 문서를 따라 작성됨.

## Test plan

- [x] 17 단위 테스트 통과 (schemas + repositories) — `uv run pytest`
- [x] docker compose 회귀 — 컨테이너 부팅 시 yoyo 마이그레이션 자동 적용. 5 테이블 + 인덱스 생성 확인 (`\dt`)
- [x] 첫 MCP 세션 후 lifespan 실행 (asyncpg pool ready / "5 collections" 로그)
- [x] streamable HTTP 통합 — `agent_task.upsert` / `agent_task.count` 호출 정상

## 알려진 한계 / Future work

- **FastMCP streamable-http 의 lifespan 이 per-MCP-session** — 세션마다 pool 생성/해제. M3 demo 에는 무리 없으나 long-lived 운영 시 비효율. M5+ 에서 외부 pool + 주입 패턴으로 개선 가능.
- **testcontainers 미도입** — 실 Postgres (compose) 위에서 테스트. CI 자동화 시점에 추가.
- 본 MCP 는 thin CRUD — 비즈니스 규칙 / 검증은 호출자 (L) 의 책임.

## Sandbox 환경

- `vonkernel/guestbook` (private) — 향후 #36 (IssueTracker) / #37 (Wiki) MCP 가 외부 sync 대상으로 사용
- `.env.example` 에 GitHub 토큰 placeholder 이미 추가됨 (#49)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
