### PR TITLE
feat(agent): Librarian — Doc Store 단일 창구 + ReAct 자연어 매핑 (#38)

### DIFF
--- a/agents/librarian/Dockerfile
+++ b/agents/librarian/Dockerfile
@@ -1,0 +1,43 @@
+# syntax=docker/dockerfile:1
+#
+# Librarian (L) 에이전트 이미지 — self-hosted OSS 경로.
+#
+# 베이스: python:3.13-slim
+# 런타임: FastAPI + uvicorn. 엔드포인트는 librarian_agent.server:app 에서 정의.
+# Backend MCP: Doc Store (DOC_STORE_MCP_URL).
+# 영속: AsyncPostgresSaver (Postgres `langgraph` DB) — DATABASE_URI.
+#
+# 빌드 (레포 루트에서):
+#   docker build -f agents/librarian/Dockerfile -t dev-team/librarian:latest .
+#
+# 런타임 변수:
+#   ANTHROPIC_API_KEY       (필수, overrides/librarian.yaml 통해 주입)
+#   DOC_STORE_MCP_URL       (필수, 예: http://doc-store-mcp:8000/mcp)
+#   DATABASE_URI            (선택, 미설정 시 in-memory checkpointer)
+
+FROM python:3.13-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+# -- 1) shared 패키지 설치 --
+COPY shared /app/shared
+RUN pip install -e /app/shared
+
+# -- 2) librarian 패키지 설치 --
+COPY agents/librarian /app/librarian
+RUN sed -i '/^\[tool\.uv\.sources\]/,/^$/d' /app/librarian/pyproject.toml \
+ && pip install -e /app/librarian
+
+WORKDIR /app/librarian
+EXPOSE 8000
+
+CMD ["uvicorn", "librarian_agent.server:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/agents/librarian/config/base.yaml
+++ b/agents/librarian/config/base.yaml
@@ -1,0 +1,107 @@
+# Librarian (L) 에이전트 — base config (이미지에 baked-in)
+#
+# 전체 설계 의도: docs/proposal.md §2.5 / §3.2
+# 본 이슈: #38
+#
+# ⚠️  override 금지 필드: role, specialty, persona, workflow
+# ⚠️  `llm.api_key` 는 반드시 overrides/librarian.yaml 에서 주입 (base 에는 비워둠)
+
+role: librarian
+
+persona: |
+  당신은 이 개발팀의 "Librarian" 에이전트 — 사서 입니다.
+  다른 에이전트들 (Primary / Architect / Engineer / QA) 이 Doc Store 의
+  데이터에 접근하는 단일 창구 역할을 합니다.
+
+  ## 핵심 책임
+
+  1. Doc Store 단일 창구
+     - 다른 에이전트는 Doc Store 에 직접 접근하지 않습니다.
+     - 자연어 요청을 받아 적절한 도구를 호출하고 결과를 자연어로 정리해
+       응답합니다.
+     - 데이터 자체의 SoT 는 Doc Store 입니다 — 본 에이전트는 read/write
+       proxy + 자연어 layer.
+
+  2. 자연어 → tool 매핑
+     - 호출 에이전트는 자연어로 요청합니다 (예: "guestbook 의 PRD 저장",
+       "context X 의 대화 로그 조회").
+     - 당신은 LLM 추론으로 어떤 collection 의 어떤 op 를 호출할지 결정하고,
+       필요하면 여러 도구를 순차 호출합니다 (ReAct).
+     - 도메인 enum (`prd` / `epic` / `story` 등) 은 코드에 박혀있지 않으며,
+       당신이 매 요청 컨텍스트에 따라 적절한 page_type / type 필드 값을
+       정합니다.
+
+  3. 결과 포매팅
+     - tool 결과 (Pydantic 모델) 를 호출 에이전트가 읽기 좋은 자연어로
+       정리합니다.
+     - 식별자 (id / slug / ref) 는 명시적으로 포함하여 호출자가 후속 도구
+       호출에 사용할 수 있게 합니다.
+
+  ## 도구 카탈로그 — Doc Store 5 collection thin pass-through
+
+  - `wiki_pages` — 위키 문서 (PRD / ADR / business_rule 등, `page_type` 필드로 분류)
+  - `issues` — 이슈 mirror (Epic / Story / Task 등, `type` 필드로 분류)
+  - `agent_tasks` — 작업 단위 (CHR 가 영속한 task 메타)
+  - `agent_sessions` — task 안의 대화 흐름 (contextId 별)
+  - `agent_items` — 개별 메시지
+
+  자세한 op 면은 도구 schema (bind_tools) 를 참조하세요.
+
+  ## 행동 원칙
+
+  - 호출자의 요청에 가장 가까운 도구를 선택합니다. 모호하면 자연어로
+    재질의합니다.
+  - 도구 호출 결과를 그대로 dump 하지 않고, 호출자가 필요한 핵심을 추려
+    응답합니다.
+  - 데이터에 없는 사실을 만들어내지 않습니다 (할루시네이션 금지).
+  - 모르는 entity / id 가 들어오면 "찾을 수 없음" 으로 명시합니다.
+
+  ## 협업 경계
+
+  - Primary (P): 가장 빈번한 호출자 — PRD / Epic / Story 영속 + 진행 상황 조회
+  - Architect (A) / Engineer / QA (M4+): 코드 구조 / 설계 spec 조회
+  - User Gateway (UG): 직접 호출 X — 사용자는 P 를 통해 간접 접근
+
+  ## 현재 단계 제약 (M3)
+
+  현재 노출 도구는 Doc Store 5 collection 의 일부 op (CRUD 중 read 위주 +
+  필요한 write). Atlas (graph) / 코드 구조 분석 / diff 색인은 M4+ 에서
+  추가됩니다. 미구현 기능 호출이 들어오면 "본 단계에선 미지원" 으로
+  명시합니다.
+
+llm:
+  provider: anthropic
+  model: claude-sonnet-4-6
+  temperature: 0.2          # tool 호출 정확성 우선 — Primary 보다 낮게
+  api_key: ""               # override 에서 ${ANTHROPIC_API_KEY} 로 주입
+
+# 클라이언트 측 — Librarian 이 먼저 호출할 피어. M3 단계엔 없음 (다른 에이전트
+# 가 L 을 호출하는 구도. L 은 응답만).
+a2a_peers: []
+
+# 서버 측 — Librarian 서버로 들어오는 호출을 허용할 주체.
+# M3 단계엔 Primary 만 (M4+ 에서 A 등 추가).
+allowed_clients:
+  - primary
+
+# AgentCard
+agent_card:
+  version: "0.1"
+  url: http://librarian:8000/a2a/librarian
+  protocol_binding: JSONRPC
+  capabilities:
+    streaming: true
+    pushNotifications: false
+  default_input_modes: [text/plain]
+  default_output_modes: [text/plain]
+  provider:
+    organization: dev-team
+    url: https://github.com/vonkernel/dev-team
+  skills:
+    - id: librarian.doc_store_query
+      name: Doc Store Query / Mutation
+      description: |
+        자연어 요청을 받아 Doc Store 의 5 collection (wiki_pages / issues /
+        agent_tasks / agent_sessions / agent_items) 의 read/write 도구를
+        호출하고 결과를 자연어로 정리해 응답합니다.
+      tags: [librarian, doc-store, query, mutation, react]

--- a/agents/librarian/pyproject.toml
+++ b/agents/librarian/pyproject.toml
@@ -1,0 +1,35 @@
+[project]
+name = "librarian-agent"
+version = "0.1.0"
+description = "Librarian (L) 에이전트 — Doc Store 단일 창구 + 자연어 → tool 매핑 (LLM ReAct)"
+requires-python = ">=3.13,<3.14"
+
+# langchain/langgraph 생태계는 dev-team-shared 를 통해 들어오지만, 본 패키지가
+# 직접 사용하는 것만 최소한으로 명시.
+dependencies = [
+  "dev-team-shared",
+  "langgraph>=1.1.9",
+  "langgraph-checkpoint-postgres>=3.0.5",
+  "fastapi>=0.120.0",
+  "uvicorn[standard]>=0.32.0",
+]
+
+[project.optional-dependencies]
+dev = [
+  "pytest>=9.0.3",
+  "pytest-asyncio>=1.3.0",
+]
+
+[tool.uv.sources]
+dev-team-shared = { workspace = true }
+
+[build-system]
+requires = ["hatchling>=1.29.0"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/librarian_agent"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]

--- a/agents/librarian/scripts/verify_sandbox.py
+++ b/agents/librarian/scripts/verify_sandbox.py
@@ -1,0 +1,122 @@
+"""Librarian 1차 통합 검증 스크립트.
+
+서버: http://localhost:9002 (이미 부팅된 컨테이너 가정)
+대상: A2A `SendStreamingMessage` 로 자연어 요청 → LLM 이 tool 호출 + 자연어 응답
+
+검증 시나리오 (read-only — Doc Store 데이터 변경 X):
+  1. AgentCard 정상
+  2. "wiki_pages.list" 자연어 요청 → wiki_pages_list tool 호출 + 자연어 응답
+  3. "agent_tasks 몇 개" → agent_tasks_list 호출 + count 응답
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+import uuid
+
+import httpx
+
+
+BASE = "http://localhost:9002"
+A2A_URL = f"{BASE}/a2a/librarian"
+
+
+async def fetch_agent_card() -> dict:
+    async with httpx.AsyncClient() as c:
+        r = await c.get(f"{BASE}/.well-known/agent-card.json")
+        r.raise_for_status()
+        return r.json()
+
+
+async def send_streaming_message(text: str) -> list[dict]:
+    """A2A SendStreamingMessage 호출 → 모든 SSE 이벤트 수집."""
+    payload = {
+        "jsonrpc": "2.0",
+        "id": f"verify-{uuid.uuid4()}",
+        "method": "SendStreamingMessage",
+        "params": {
+            "message": {
+                "messageId": f"msg-{uuid.uuid4()}",
+                "role": "ROLE_USER",
+                "parts": [{"text": text}],
+                "contextId": str(uuid.uuid4()),
+            },
+        },
+    }
+    events: list[dict] = []
+    async with httpx.AsyncClient(timeout=120.0) as c:
+        async with c.stream(
+            "POST", A2A_URL,
+            json=payload,
+            headers={"Accept": "text/event-stream"},
+        ) as r:
+            r.raise_for_status()
+            async for line in r.aiter_lines():
+                if line.startswith("data: "):
+                    raw = line[len("data: "):].strip()
+                    if not raw:
+                        continue
+                    try:
+                        events.append(json.loads(raw))
+                    except json.JSONDecodeError:
+                        events.append({"raw": raw})
+    return events
+
+
+def _extract_final_text(events: list[dict]) -> str:
+    """SSE events 에서 최종 자연어 응답 추출. artifact-update 이벤트의 parts.text 합침."""
+    pieces: list[str] = []
+    for e in events:
+        result = e.get("result") or {}
+        # streaming artifact chunk: result.artifact.parts[].text
+        artifact = result.get("artifact") or {}
+        for part in artifact.get("parts") or []:
+            t = part.get("text")
+            if t:
+                pieces.append(t)
+        # task status message (final): result.status.message.parts[].text
+        status_msg = (result.get("status") or {}).get("message") or {}
+        for part in status_msg.get("parts") or []:
+            t = part.get("text")
+            if t:
+                pieces.append(t)
+    return "".join(pieces)
+
+
+async def main() -> int:
+    print("[1] AgentCard fetch")
+    card = await fetch_agent_card()
+    assert card.get("name") == "librarian", f"unexpected name: {card.get('name')}"
+    print(f"    name={card['name']}, streaming={card['capabilities']['streaming']}")
+
+    print("\n[2] '위키 페이지 목록 알려줘' (read-only)")
+    events = await send_streaming_message(
+        "doc-store 의 wiki_pages 를 page_type 무관하게 list 해줘. limit=5 면 충분.",
+    )
+    print(f"    received {len(events)} SSE events")
+    final = _extract_final_text(events)
+    print(f"    final text (first 300):\n      {final[:300]!r}")
+    if not final:
+        print("    !! 자연어 응답 없음 — events:")
+        for i, e in enumerate(events[:6]):
+            print(f"      [{i}] {json.dumps(e, ensure_ascii=False)[:200]}")
+        return 1
+
+    print("\n[3] 'agent_tasks 몇 개?' (count via list)")
+    events = await send_streaming_message(
+        "agent_tasks collection 에 현재 몇 개의 task 가 있는지 list 도구로 확인하고 개수만 알려줘.",
+    )
+    final = _extract_final_text(events)
+    print(f"    final text (first 300):\n      {final[:300]!r}")
+    if not final:
+        print("    !! 자연어 응답 없음")
+        return 1
+
+    print("\nALL PASS ✅")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/agents/librarian/scripts/verify_sandbox.sh
+++ b/agents/librarian/scripts/verify_sandbox.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# Librarian (L) 1차 통합 검증 — A2A SendStreamingMessage 자연어 요청.
+#
+# 사용:
+#   bash agents/librarian/scripts/verify_sandbox.sh
+#
+# 사전 조건:
+#   .env 의 ANTHROPIC_API_KEY (Primary 와 공유)
+#   doc-store-mcp 컨테이너 부팅 (--profile mcp 또는 agents)
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+COMPOSE_FILE="$REPO_ROOT/infra/docker-compose.yml"
+AGENT_DIR="$REPO_ROOT/agents/librarian"
+
+if ! awk -F= '$1=="ANTHROPIC_API_KEY" && length($2)>0 {found=1} END{exit !found}' "$REPO_ROOT/.env"; then
+  echo "ERR: ANTHROPIC_API_KEY missing/empty in .env" >&2
+  exit 1
+fi
+
+echo "==> 1. doc-store-mcp + librarian 부팅 (rebuild)"
+( cd "$REPO_ROOT/infra" && docker compose --profile agents up -d --build doc-store-mcp librarian )
+
+echo "==> 2. 부팅 대기 (5s)"
+sleep 5
+
+echo "==> 3. health check (logs)"
+docker compose -f "$COMPOSE_FILE" logs librarian --tail 5
+
+echo "==> 4. 자연어 ReAct 시나리오 실행"
+( cd "$AGENT_DIR" && uv run python scripts/verify_sandbox.py )
+
+echo
+echo "==================================================================="
+echo "검증 완료. librarian — http://localhost:9002/a2a/librarian"
+echo
+echo "정리:"
+echo "  docker compose -f $COMPOSE_FILE --profile agents down librarian"
+echo "==================================================================="

--- a/agents/librarian/src/librarian_agent/__init__.py
+++ b/agents/librarian/src/librarian_agent/__init__.py
@@ -1,0 +1,5 @@
+"""Librarian (L) 에이전트.
+
+다른 에이전트들이 Doc Store / (M4+ Atlas) 에 접근하는 단일 read/write 창구.
+자연어 요청을 도구 호출로 매핑 (LLM ReAct).
+"""

--- a/agents/librarian/src/librarian_agent/graph.py
+++ b/agents/librarian/src/librarian_agent/graph.py
@@ -1,0 +1,186 @@
+"""Librarian 의 LangGraph 그래프 — ReAct 패턴.
+
+흐름 (mermaid):
+    START → llm_call → (tool_calls 있음? → tools → llm_call) → END
+
+- `llm_call` 노드: persona + 누적 messages → LLM (with bind_tools) → AIMessage
+  · AIMessage 에 tool_calls 가 있으면 다음 라운드에서 도구 실행
+  · 없으면 자연어 응답 완성 → END
+- `tools` 노드: AIMessage.tool_calls 의 각 호출을 실행 → ToolMessage 들로 반환
+- conditional edge `should_continue` 가 분기 결정
+
+Primary 의 단순 1-노드 패턴 위에서 ReAct 루프 추가. langgraph.prebuilt.ToolNode
+대신 직접 노드 구현 — 의존 최소 + 동작 명시.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Annotated, Any, TypedDict
+
+from dev_team_shared.config_loader import load_config
+from dev_team_shared.llm import LLMSpec, create_chat_model
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import AnyMessage, SystemMessage, ToolMessage
+from langchain_core.tools import BaseTool
+from langgraph.checkpoint.base import BaseCheckpointSaver
+from langgraph.graph import END, START, StateGraph
+from langgraph.graph.message import add_messages
+
+logger = logging.getLogger(__name__)
+
+# 패키지 위치 기준 고정 경로:
+# graph.py = agents/librarian/src/librarian_agent/graph.py → parents[2] = agents/librarian/
+_PACKAGE_ROOT = Path(__file__).resolve().parents[2]
+_BASE_CONFIG_PATH = _PACKAGE_ROOT / "config" / "base.yaml"
+_OVERRIDE_CONFIG_PATH = _PACKAGE_ROOT / "config" / "override.yaml"
+
+
+class State(TypedDict):
+    """LangGraph 상태. Primary 와 동일한 messages reducer."""
+
+    messages: Annotated[list[AnyMessage], add_messages]
+
+
+def load_runtime_config() -> dict[str, Any]:
+    """Role Config 로드."""
+    return load_config(_BASE_CONFIG_PATH, _OVERRIDE_CONFIG_PATH)
+
+
+def build_llm(llm_cfg: dict[str, Any]) -> BaseChatModel:
+    spec = LLMSpec.from_config(llm_cfg)
+    return create_chat_model(spec)
+
+
+def _make_llm_call_node(persona: str, llm_with_tools: BaseChatModel):
+    """persona / tools-bound LLM 캡처한 비동기 노드."""
+
+    async def _llm_call(state: State) -> dict[str, list[AnyMessage]]:
+        system = SystemMessage(content=persona)
+        try:
+            response = await llm_with_tools.ainvoke([system, *state["messages"]])
+        except Exception as exc:
+            logger.exception("LLM call failed in `_llm_call` node")
+            detail = f"{type(exc).__name__}: {exc}"
+            if "credit balance" in str(exc).lower():
+                detail += (
+                    " — Anthropic 크레딧 부족 가능성. "
+                    "https://console.anthropic.com/settings/billing 확인."
+                )
+            raise RuntimeError(f"LLM call failed — {detail}") from exc
+        return {"messages": [response]}
+
+    return _llm_call
+
+
+def _make_tool_node(tools: list[BaseTool]):
+    """tool_calls 를 실행해 ToolMessage 들로 반환하는 노드.
+
+    langgraph.prebuilt.ToolNode 와 등가. 직접 구현 — prebuilt 의존 회피 +
+    동작 명시 (디버깅 용이).
+    """
+    tools_by_name = {t.name: t for t in tools}
+
+    async def _tools(state: State) -> dict[str, list[AnyMessage]]:
+        last = state["messages"][-1]
+        tool_calls = getattr(last, "tool_calls", None) or []
+        if not tool_calls:
+            return {"messages": []}
+
+        outputs: list[AnyMessage] = []
+        for tc in tool_calls:
+            name = tc.get("name") or ""
+            tool = tools_by_name.get(name)
+            tc_id = tc.get("id") or ""
+            if tool is None:
+                outputs.append(
+                    ToolMessage(
+                        content=f"unknown tool: {name!r}",
+                        tool_call_id=tc_id,
+                        name=name,
+                    ),
+                )
+                continue
+            try:
+                result = await tool.ainvoke(tc.get("args") or {})
+            except Exception as exc:
+                logger.exception("tool %r raised", name)
+                outputs.append(
+                    ToolMessage(
+                        content=f"tool error ({type(exc).__name__}): {exc}",
+                        tool_call_id=tc_id,
+                        name=name,
+                    ),
+                )
+                continue
+            outputs.append(
+                ToolMessage(
+                    content=_serialize(result),
+                    tool_call_id=tc_id,
+                    name=name,
+                ),
+            )
+        return {"messages": outputs}
+
+    return _tools
+
+
+def _should_continue(state: State) -> str:
+    """tool_calls 가 있으면 'tools' 노드로, 없으면 END."""
+    last = state["messages"][-1]
+    tool_calls = getattr(last, "tool_calls", None) or []
+    return "tools" if tool_calls else END
+
+
+def _serialize(value: Any) -> str:
+    """tool 결과를 ToolMessage.content (str) 로 직렬화.
+
+    Pydantic 모델 → model_dump(mode='json') 후 JSON. list / scalar / None 도 동일.
+    """
+    if value is None:
+        return "null"
+    if hasattr(value, "model_dump"):
+        return json.dumps(value.model_dump(mode="json"), ensure_ascii=False)
+    if isinstance(value, list):
+        return json.dumps(
+            [v.model_dump(mode="json") if hasattr(v, "model_dump") else v for v in value],
+            ensure_ascii=False,
+        )
+    if isinstance(value, (dict, str, int, float, bool)):
+        return json.dumps(value, ensure_ascii=False)
+    return str(value)
+
+
+def build_graph(
+    *,
+    persona: str,
+    llm: BaseChatModel,
+    tools: list[BaseTool],
+    checkpointer: BaseCheckpointSaver | None = None,
+) -> Any:
+    """persona / llm / tools / checkpointer 주입해 ReAct 그래프 컴파일.
+
+    Args:
+        persona: SystemMessage content.
+        llm: BaseChatModel (tools 와 별도 — 본 함수가 bind_tools).
+        tools: LangChain tool 목록 (build_tools(client) 결과).
+        checkpointer: AsyncPostgresSaver 등. None 이면 in-memory.
+    """
+    llm_with_tools = llm.bind_tools(tools)
+
+    builder = StateGraph(State)
+    builder.add_node("llm_call", _make_llm_call_node(persona, llm_with_tools))
+    builder.add_node("tools", _make_tool_node(tools))
+    builder.add_edge(START, "llm_call")
+    builder.add_conditional_edges(
+        "llm_call",
+        _should_continue,
+        {"tools": "tools", END: END},
+    )
+    builder.add_edge("tools", "llm_call")
+    return builder.compile(checkpointer=checkpointer)
+
+
+__all__ = ["State", "build_graph", "build_llm", "load_runtime_config"]

--- a/agents/librarian/src/librarian_agent/server.py
+++ b/agents/librarian/src/librarian_agent/server.py
@@ -1,0 +1,129 @@
+"""Librarian (L) 에이전트 FastAPI HTTP 서버.
+
+Primary 의 server.py 미러 + DocStoreClient (MCP) wiring.
+
+lifespan 책임:
+  1) Role Config 로드 → persona / LLM 준비
+  2) DocStoreClient (Streamable HTTP MCP) 연결 → tools build → graph compile
+  3) (선택) AsyncPostgresSaver wiring
+  4) AgentCard build → app.state 세팅
+  5) 공용 A2A 라우터 include
+
+환경변수:
+  ANTHROPIC_API_KEY       (필수, overrides/librarian.yaml 통해 주입)
+  DOC_STORE_MCP_URL       (필수, 예: http://doc-store-mcp:8000/mcp)
+  DATABASE_URI            (선택, 미설정 시 in-memory checkpointer)
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from contextlib import asynccontextmanager
+
+from dev_team_shared.a2a import build_agent_card
+from dev_team_shared.a2a.server import make_a2a_router
+from dev_team_shared.a2a.server.graph_handlers import (
+    GraphSendMessageHandler,
+    GraphSendStreamingMessageHandler,
+)
+from dev_team_shared.doc_store import DocStoreClient
+from dev_team_shared.mcp_client import StreamableMCPClient
+from fastapi import FastAPI
+from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
+
+from librarian_agent.graph import build_graph, build_llm, load_runtime_config
+from librarian_agent.tools import build_tools
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+_ASSISTANT_ID = "librarian"
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    """기동: config → LLM → MCP client → tools → graph compile → state 세팅."""
+    config = load_runtime_config()
+    persona = config.get("persona")
+    if not persona:
+        raise RuntimeError("config.persona is required")
+    llm = build_llm(config.get("llm") or {})
+
+    doc_store_url = os.environ.get("DOC_STORE_MCP_URL")
+    if not doc_store_url:
+        raise RuntimeError("DOC_STORE_MCP_URL env required")
+    database_uri = os.environ.get("DATABASE_URI")
+    agent_card = build_agent_card(config)
+
+    # Doc Store MCP 연결 — lifespan 동안 유지. shutdown 에서 aclose.
+    mcp = await StreamableMCPClient.connect(doc_store_url)
+    try:
+        client = DocStoreClient(mcp)
+        tools = build_tools(client)
+        logger.info(
+            "librarian agent ready (doc_store=%s, tools=%d)",
+            doc_store_url,
+            len(tools),
+        )
+
+        if database_uri:
+            async with AsyncPostgresSaver.from_conn_string(database_uri) as checkpointer:
+                await checkpointer.setup()
+                app.state.graph = build_graph(
+                    persona=persona, llm=llm, tools=tools, checkpointer=checkpointer,
+                )
+                app.state.agent_card = agent_card
+                logger.info(
+                    "librarian agent ready (Postgres checkpointer at %s)",
+                    _mask_dsn(database_uri),
+                )
+                yield
+        else:
+            app.state.graph = build_graph(
+                persona=persona, llm=llm, tools=tools, checkpointer=None,
+            )
+            app.state.agent_card = agent_card
+            logger.warning(
+                "DATABASE_URI not set — running with in-memory state "
+                "(non-durable across restarts)",
+            )
+            yield
+    finally:
+        await mcp.aclose()
+
+
+app = FastAPI(
+    lifespan=lifespan,
+    title="Librarian Agent (dev-team)",
+    description=(
+        "A2A-compatible LangGraph agent — Doc Store 단일 창구. "
+        "자연어 → tool 매핑 (LLM ReAct)."
+    ),
+)
+
+app.include_router(
+    make_a2a_router(
+        assistant_id=_ASSISTANT_ID,
+        handlers=[
+            GraphSendMessageHandler(),
+            GraphSendStreamingMessageHandler(),
+        ],
+    ),
+)
+
+
+def _mask_dsn(dsn: str) -> str:
+    if "@" in dsn and "://" in dsn:
+        scheme, rest = dsn.split("://", 1)
+        creds, host = rest.split("@", 1)
+        if ":" in creds:
+            user = creds.split(":", 1)[0]
+            return f"{scheme}://{user}:***@{host}"
+    return dsn
+
+
+__all__ = ["app"]

--- a/agents/librarian/src/librarian_agent/tools.py
+++ b/agents/librarian/src/librarian_agent/tools.py
@@ -1,0 +1,205 @@
+"""Librarian 의 LangChain tool 정의.
+
+Doc Store 의 5 collection thin pass-through. LangChain `@tool` 로 wrapping 해
+LLM 의 `bind_tools()` 에 부착 — LLM 이 자연어 → tool 매핑 결정.
+
+도메인 wrapper (`upsert_prd` 등) 박지 않음 (root CLAUDE.md "에이전트 ↔ 외부
+도구 운영 원칙"). LLM 이 매 요청 컨텍스트에 맞춰 page_type / type 필드 결정.
+
+M3 노출 op (delete / count 미노출 — 호출자 불필요):
+- wiki_pages: create / update / get / list / get_by_slug
+- issues:     create / update / get / list
+- agent_tasks: get / list
+- agent_sessions: get / list / list_by_task / find_by_context
+- agent_items:    list / list_by_session
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from dev_team_shared.doc_store import (
+    AgentItemRead,
+    AgentSessionRead,
+    AgentSessionUpdate,
+    AgentTaskRead,
+    DocStoreClient,
+    IssueCreate,
+    IssueRead,
+    IssueUpdate,
+    WikiPageCreate,
+    WikiPageRead,
+    WikiPageUpdate,
+)
+from langchain_core.tools import BaseTool, tool
+
+
+def build_tools(client: DocStoreClient) -> list[BaseTool]:
+    """DocStoreClient 클로저 캡처 → LangChain tool 목록 반환.
+
+    server.lifespan 에서 client 생성 후 호출. 결과를 LLM `bind_tools()` 에 부착.
+    """
+
+    # ──────────────────────────────────────────────────────────────────
+    # wiki_pages
+    # ──────────────────────────────────────────────────────────────────
+
+    @tool
+    async def wiki_pages_create(doc: WikiPageCreate) -> WikiPageRead:
+        """Create a wiki page (PRD / ADR / business_rule 등). page_type 필드로 분류."""
+        return await client.wiki_page_create(doc)
+
+    @tool
+    async def wiki_pages_update(id: str, patch: WikiPageUpdate) -> WikiPageRead | None:
+        """Update wiki page by id (UUID). 미존재 시 null."""
+        return await client.wiki_page_update(UUID(id), patch)
+
+    @tool
+    async def wiki_pages_get(id: str) -> WikiPageRead | None:
+        """Get wiki page by id (UUID). 미존재 시 null."""
+        return await client.wiki_page_get(UUID(id))
+
+    @tool
+    async def wiki_pages_get_by_slug(slug: str) -> WikiPageRead | None:
+        """Get wiki page by slug (예: 'prd-guestbook'). 미존재 시 null."""
+        return await client.wiki_page_get_by_slug(slug)
+
+    @tool
+    async def wiki_pages_list(
+        where: dict[str, Any] | None = None,
+        limit: int = 100,
+        offset: int = 0,
+        order_by: str = "created_at DESC",
+    ) -> list[WikiPageRead]:
+        """List wiki pages. where 는 단순 equality 필터 (예: {"page_type": "prd"})."""
+        return await client.wiki_page_list(
+            where=where, limit=limit, offset=offset, order_by=order_by,
+        )
+
+    # ──────────────────────────────────────────────────────────────────
+    # issues
+    # ──────────────────────────────────────────────────────────────────
+
+    @tool
+    async def issues_create(doc: IssueCreate) -> IssueRead:
+        """Create an issue mirror (Epic / Story / Task 등). type 필드로 분류."""
+        return await client.issue_create(doc)
+
+    @tool
+    async def issues_update(id: str, patch: IssueUpdate) -> IssueRead | None:
+        """Update issue by id (UUID). 미존재 시 null."""
+        return await client.issue_update(UUID(id), patch)
+
+    @tool
+    async def issues_get(id: str) -> IssueRead | None:
+        """Get issue by id (UUID). 미존재 시 null."""
+        return await client.issue_get(UUID(id))
+
+    @tool
+    async def issues_list(
+        where: dict[str, Any] | None = None,
+        limit: int = 100,
+        offset: int = 0,
+        order_by: str = "created_at DESC",
+    ) -> list[IssueRead]:
+        """List issues. where 예: {"type": "epic"} or {"status": "open"}."""
+        return await client.issue_list(
+            where=where, limit=limit, offset=offset, order_by=order_by,
+        )
+
+    # ──────────────────────────────────────────────────────────────────
+    # agent_tasks (read-only at M3)
+    # ──────────────────────────────────────────────────────────────────
+
+    @tool
+    async def agent_tasks_get(id: str) -> AgentTaskRead | None:
+        """Get agent_task by id (UUID). 미존재 시 null."""
+        return await client.agent_task_get(UUID(id))
+
+    @tool
+    async def agent_tasks_list(
+        where: dict[str, Any] | None = None,
+        limit: int = 100,
+        offset: int = 0,
+        order_by: str = "created_at DESC",
+    ) -> list[AgentTaskRead]:
+        """List agent tasks. CHR 가 영속한 작업 단위 메타."""
+        return await client.agent_task_list(
+            where=where, limit=limit, offset=offset, order_by=order_by,
+        )
+
+    # ──────────────────────────────────────────────────────────────────
+    # agent_sessions
+    # ──────────────────────────────────────────────────────────────────
+
+    @tool
+    async def agent_sessions_get(id: str) -> AgentSessionRead | None:
+        """Get agent_session by id (UUID). 미존재 시 null."""
+        return await client.agent_session_get(UUID(id))
+
+    @tool
+    async def agent_sessions_list(
+        where: dict[str, Any] | None = None,
+        limit: int = 100,
+        offset: int = 0,
+        order_by: str = "started_at DESC",
+    ) -> list[AgentSessionRead]:
+        """List agent sessions (대화 흐름)."""
+        return await client.agent_session_list(
+            where=where, limit=limit, offset=offset, order_by=order_by,
+        )
+
+    @tool
+    async def agent_sessions_list_by_task(task_id: str) -> list[AgentSessionRead]:
+        """List sessions for a task (UUID)."""
+        return await client.agent_session_list_by_task(UUID(task_id))
+
+    @tool
+    async def agent_sessions_find_by_context(context_id: str) -> AgentSessionRead | None:
+        """contextId 로 session 1개 lookup. 미존재 시 null. chronicler 로그 entry."""
+        return await client.agent_session_find_by_context(context_id)
+
+    # ──────────────────────────────────────────────────────────────────
+    # agent_items
+    # ──────────────────────────────────────────────────────────────────
+
+    @tool
+    async def agent_items_list(
+        where: dict[str, Any] | None = None,
+        limit: int = 100,
+        offset: int = 0,
+        order_by: str = "created_at ASC",
+    ) -> list[AgentItemRead]:
+        """List agent items (메시지)."""
+        return await client.agent_item_list(
+            where=where, limit=limit, offset=offset, order_by=order_by,
+        )
+
+    @tool
+    async def agent_items_list_by_session(session_id: str) -> list[AgentItemRead]:
+        """List items for a session (UUID). chronicler 로그 본문."""
+        return await client.agent_item_list_by_session(UUID(session_id))
+
+    return [
+        wiki_pages_create,
+        wiki_pages_update,
+        wiki_pages_get,
+        wiki_pages_get_by_slug,
+        wiki_pages_list,
+        issues_create,
+        issues_update,
+        issues_get,
+        issues_list,
+        agent_tasks_get,
+        agent_tasks_list,
+        agent_sessions_get,
+        agent_sessions_list,
+        agent_sessions_list_by_task,
+        agent_sessions_find_by_context,
+        agent_items_list,
+        agent_items_list_by_session,
+    ]
+
+
+__all__ = ["build_tools"]

--- a/agents/librarian/tests/test_graph_helpers.py
+++ b/agents/librarian/tests/test_graph_helpers.py
@@ -1,0 +1,146 @@
+"""Librarian 그래프 헬퍼 단위 테스트 — _serialize / _should_continue / _make_tool_node."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+from pydantic import BaseModel
+
+from librarian_agent.graph import (
+    END,
+    _make_tool_node,
+    _serialize,
+    _should_continue,
+)
+
+
+# ----------------------------------------------------------------------
+# _serialize
+# ----------------------------------------------------------------------
+
+
+class _Sample(BaseModel):
+    a: int
+    b: str
+
+
+class TestSerialize:
+    def test_none(self) -> None:
+        assert _serialize(None) == "null"
+
+    def test_pydantic_model(self) -> None:
+        out = _serialize(_Sample(a=1, b="x"))
+        assert json.loads(out) == {"a": 1, "b": "x"}
+
+    def test_list_of_models(self) -> None:
+        out = _serialize([_Sample(a=1, b="x"), _Sample(a=2, b="y")])
+        assert json.loads(out) == [{"a": 1, "b": "x"}, {"a": 2, "b": "y"}]
+
+    def test_dict(self) -> None:
+        assert json.loads(_serialize({"k": "v"})) == {"k": "v"}
+
+    def test_scalar(self) -> None:
+        assert _serialize(42) == "42"
+        assert _serialize(True) == "true"
+        assert _serialize("hello") == '"hello"'
+
+
+# ----------------------------------------------------------------------
+# _should_continue
+# ----------------------------------------------------------------------
+
+
+class TestShouldContinue:
+    def test_tool_calls_present(self) -> None:
+        last = AIMessage(
+            content="",
+            tool_calls=[{"name": "x", "args": {}, "id": "1", "type": "tool_call"}],
+        )
+        state = {"messages": [HumanMessage(content="hi"), last]}
+        assert _should_continue(state) == "tools"
+
+    def test_no_tool_calls(self) -> None:
+        last = AIMessage(content="응답")
+        state = {"messages": [HumanMessage(content="hi"), last]}
+        assert _should_continue(state) is END
+
+
+# ----------------------------------------------------------------------
+# _make_tool_node — 실제 tool 함수 호출 / 미존재 / 예외 모두 검증
+# ----------------------------------------------------------------------
+
+
+class _FakeTool:
+    """LangChain BaseTool 의 최소 인터페이스 흉내 — `name` + `ainvoke`."""
+
+    def __init__(self, name: str, return_value: Any = None, raises: Exception | None = None) -> None:
+        self.name = name
+        self._return = return_value
+        self._raises = raises
+        self.calls: list[dict] = []
+
+    async def ainvoke(self, args: dict) -> Any:
+        self.calls.append(args)
+        if self._raises is not None:
+            raise self._raises
+        return self._return
+
+
+@pytest.mark.asyncio
+async def test_tool_node_executes_tool_calls() -> None:
+    fake = _FakeTool("hello_tool", return_value=_Sample(a=1, b="x"))
+    node = _make_tool_node([fake])  # type: ignore[arg-type]
+    last = AIMessage(
+        content="",
+        tool_calls=[
+            {"name": "hello_tool", "args": {"foo": "bar"}, "id": "tc1", "type": "tool_call"},
+        ],
+    )
+    out = await node({"messages": [last]})
+    assert fake.calls == [{"foo": "bar"}]
+    assert len(out["messages"]) == 1
+    msg = out["messages"][0]
+    assert isinstance(msg, ToolMessage)
+    assert msg.tool_call_id == "tc1"
+    assert json.loads(msg.content) == {"a": 1, "b": "x"}
+
+
+@pytest.mark.asyncio
+async def test_tool_node_unknown_tool_returns_error_message() -> None:
+    node = _make_tool_node([])
+    last = AIMessage(
+        content="",
+        tool_calls=[
+            {"name": "missing", "args": {}, "id": "tc1", "type": "tool_call"},
+        ],
+    )
+    out = await node({"messages": [last]})
+    msg = out["messages"][0]
+    assert "unknown tool" in msg.content
+    assert msg.tool_call_id == "tc1"
+
+
+@pytest.mark.asyncio
+async def test_tool_node_tool_exception_captured() -> None:
+    fake = _FakeTool("boom", raises=RuntimeError("kaboom"))
+    node = _make_tool_node([fake])  # type: ignore[arg-type]
+    last = AIMessage(
+        content="",
+        tool_calls=[{"name": "boom", "args": {}, "id": "tc1", "type": "tool_call"}],
+    )
+    out = await node({"messages": [last]})
+    msg = out["messages"][0]
+    assert "tool error" in msg.content
+    assert "kaboom" in msg.content
+
+
+@pytest.mark.asyncio
+async def test_tool_node_no_tool_calls_returns_empty() -> None:
+    node = _make_tool_node([])
+    last = AIMessage(content="just a response")
+    out = await node({"messages": [last]})
+    assert out["messages"] == []

--- a/agents/librarian/tests/test_tools.py
+++ b/agents/librarian/tests/test_tools.py
@@ -1,0 +1,169 @@
+"""build_tools 단위 테스트 — DocStoreClient mock 으로 tool ↔ client 메서드 매핑 검증."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+from uuid import UUID
+
+import pytest
+
+from dev_team_shared.doc_store import (
+    AgentItemRead,
+    AgentSessionRead,
+    AgentTaskRead,
+    IssueCreate,
+    IssueRead,
+    WikiPageCreate,
+    WikiPageRead,
+)
+
+from librarian_agent.tools import build_tools
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+@pytest.fixture
+def mock_client():
+    """DocStoreClient 의 모든 메서드를 AsyncMock 으로 stub."""
+    client = AsyncMock()
+    return client
+
+
+def test_build_tools_returns_expected_tool_names(mock_client) -> None:
+    tools = build_tools(mock_client)
+    names = sorted(t.name for t in tools)
+    assert names == sorted([
+        "wiki_pages_create",
+        "wiki_pages_update",
+        "wiki_pages_get",
+        "wiki_pages_get_by_slug",
+        "wiki_pages_list",
+        "issues_create",
+        "issues_update",
+        "issues_get",
+        "issues_list",
+        "agent_tasks_get",
+        "agent_tasks_list",
+        "agent_sessions_get",
+        "agent_sessions_list",
+        "agent_sessions_list_by_task",
+        "agent_sessions_find_by_context",
+        "agent_items_list",
+        "agent_items_list_by_session",
+    ])
+
+
+def _wiki_page_read(slug: str = "prd-x") -> WikiPageRead:
+    return WikiPageRead(
+        id=UUID("00000000-0000-0000-0000-000000000001"),
+        agent_task_id=UUID("00000000-0000-0000-0000-000000000099"),
+        page_type="prd",
+        slug=slug,
+        title="PRD X",
+        content_md="# body",
+        status="draft",
+        author_agent="primary",
+        references_issues=[],
+        references_pages=[],
+        structured={},
+        external_refs={},
+        last_synced_at=None,
+        metadata={},
+        version=1,
+        created_at=_now(),
+        updated_at=_now(),
+    )
+
+
+def _issue_read() -> IssueRead:
+    return IssueRead(
+        id=UUID("00000000-0000-0000-0000-000000000002"),
+        agent_task_id=UUID("00000000-0000-0000-0000-000000000099"),
+        type="epic",
+        title="Epic 1",
+        body_md="...",
+        status="draft",
+        parent_issue_id=None,
+        labels=[],
+        external_refs={},
+        last_synced_at=None,
+        metadata={},
+        version=1,
+        created_at=_now(),
+        updated_at=_now(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_wiki_pages_create_forwards_to_client(mock_client) -> None:
+    tools = {t.name: t for t in build_tools(mock_client)}
+    expected = _wiki_page_read()
+    mock_client.wiki_page_create = AsyncMock(return_value=expected)
+
+    doc = WikiPageCreate(
+        agent_task_id=UUID("00000000-0000-0000-0000-000000000099"),
+        page_type="prd",
+        slug="prd-x",
+        title="PRD X",
+        content_md="# body",
+        author_agent="primary",
+    )
+    result = await tools["wiki_pages_create"].ainvoke({"doc": doc})
+    assert result == expected
+    mock_client.wiki_page_create.assert_awaited_once_with(doc)
+
+
+@pytest.mark.asyncio
+async def test_issues_create_forwards_to_client(mock_client) -> None:
+    tools = {t.name: t for t in build_tools(mock_client)}
+    expected = _issue_read()
+    mock_client.issue_create = AsyncMock(return_value=expected)
+
+    doc = IssueCreate(
+        agent_task_id=UUID("00000000-0000-0000-0000-000000000099"),
+        type="epic",
+        title="Epic 1",
+        body_md="...",
+    )
+    result = await tools["issues_create"].ainvoke({"doc": doc})
+    assert result == expected
+    mock_client.issue_create.assert_awaited_once_with(doc)
+
+
+@pytest.mark.asyncio
+async def test_agent_sessions_find_by_context_forwards(mock_client) -> None:
+    tools = {t.name: t for t in build_tools(mock_client)}
+    mock_client.agent_session_find_by_context = AsyncMock(return_value=None)
+
+    result = await tools["agent_sessions_find_by_context"].ainvoke({"context_id": "ctx-1"})
+    assert result is None
+    mock_client.agent_session_find_by_context.assert_awaited_once_with("ctx-1")
+
+
+@pytest.mark.asyncio
+async def test_agent_items_list_by_session_converts_uuid(mock_client) -> None:
+    tools = {t.name: t for t in build_tools(mock_client)}
+    mock_client.agent_item_list_by_session = AsyncMock(return_value=[])
+
+    sid_str = "00000000-0000-0000-0000-000000000003"
+    await tools["agent_items_list_by_session"].ainvoke({"session_id": sid_str})
+    mock_client.agent_item_list_by_session.assert_awaited_once_with(UUID(sid_str))
+
+
+@pytest.mark.asyncio
+async def test_wiki_pages_list_forwards_args(mock_client) -> None:
+    tools = {t.name: t for t in build_tools(mock_client)}
+    mock_client.wiki_page_list = AsyncMock(return_value=[])
+
+    await tools["wiki_pages_list"].ainvoke({
+        "where": {"page_type": "prd"},
+        "limit": 50,
+        "offset": 0,
+        "order_by": "created_at DESC",
+    })
+    mock_client.wiki_page_list.assert_awaited_once_with(
+        where={"page_type": "prd"}, limit=50, offset=0, order_by="created_at DESC",
+    )

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -148,6 +148,36 @@ services:
       valkey:
         condition: service_started
 
+  # Librarian (L) — Doc Store 단일 창구 (#38).
+  # 자연어 요청을 받아 LLM 추론으로 Doc Store MCP 도구 호출.
+
+  librarian:
+    profiles: ["agents"]
+    build:
+      context: ..                                   # repo root (shared + agents/librarian 포함)
+      dockerfile: agents/librarian/Dockerfile
+    image: dev-team/librarian:latest
+    container_name: dev-team-librarian
+    restart: unless-stopped
+    env_file:
+      - ../.env                                     # ANTHROPIC_API_KEY 등 주입
+    environment:
+      # AsyncPostgresSaver 체크포인트 DSN.
+      DATABASE_URI: "postgres://${POSTGRES_USER:-devteam}:${POSTGRES_PASSWORD:-devteam_postgres}@postgres:5432/${POSTGRES_DB:-langgraph}"
+      # Doc Store MCP — librarian 이 자연어 요청을 받아 호출하는 단일 backend.
+      DOC_STORE_MCP_URL: "http://doc-store-mcp:8000/mcp"
+    volumes:
+      - ../overrides/librarian.yaml:/app/librarian/config/override.yaml:ro
+    ports:
+      - "9002:8000"                                 # 호스트 9002 ← 컨테이너 8000 (root CLAUDE.md 포트 컨벤션)
+    depends_on:
+      postgres:
+        condition: service_healthy
+      postgres-init:
+        condition: service_completed_successfully
+      doc-store-mcp:
+        condition: service_started
+
   # MCP 서버군 (profile: mcp 또는 agents).
   # 모든 MCP 는 streamable HTTP transport (MCP spec 2025-06-18). 컨테이너 내부 8000.
 

--- a/overrides/librarian.yaml.example
+++ b/overrides/librarian.yaml.example
@@ -1,0 +1,10 @@
+# Librarian (L) 에이전트 override config.
+#
+# docker compose 가 이 파일을 `/app/librarian/config/override.yaml` 로 마운트.
+# 컨테이너 기동 시 shared.config_loader 가 base.yaml 과 deep merge.
+#
+# ⚠️  평문 시크릿 금지 — `${ENV_VAR}` 로 env 참조만, 실제 값은 레포 루트 `.env` 에.
+# ⚠️  Override 금지 필드 (config_loader denylist): role, specialty, persona, workflow
+
+llm:
+  api_key: ${ANTHROPIC_API_KEY}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.13,<3.14"
 # 루트는 빈 메타 — 실제 구현은 workspace 멤버에 있음
 
 [tool.uv.workspace]
-members = ["shared", "agents/primary", "user-gateway"]
+members = ["shared", "agents/primary", "agents/librarian", "user-gateway"]
 
 [tool.ruff]
 line-length = 100

--- a/uv.lock
+++ b/uv.lock
@@ -6,6 +6,7 @@ requires-python = "==3.13.*"
 members = [
     "dev-team",
     "dev-team-shared",
+    "librarian-agent",
     "primary-agent",
     "user-gateway",
 ]
@@ -565,6 +566,36 @@ sdist = { url = "https://files.pythonhosted.org/packages/6f/75/1ee27b3510bf5b1b5
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/76/53033db34ffccd25d62c32b23b9468f7228b455da6976e1c420ae31555c4/langsmith-0.7.33-py3-none-any.whl", hash = "sha256:5b535b991d52d3b664ebb8dc6f95afcf8d0acb42e062ac45a54a6a4820139f20", size = 378981, upload-time = "2026-04-20T16:17:52.503Z" },
 ]
+
+[[package]]
+name = "librarian-agent"
+version = "0.1.0"
+source = { editable = "agents/librarian" }
+dependencies = [
+    { name = "dev-team-shared" },
+    { name = "fastapi" },
+    { name = "langgraph" },
+    { name = "langgraph-checkpoint-postgres" },
+    { name = "uvicorn", extra = ["standard"] },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "dev-team-shared", editable = "shared" },
+    { name = "fastapi", specifier = ">=0.120.0" },
+    { name = "langgraph", specifier = ">=1.1.9" },
+    { name = "langgraph-checkpoint-postgres", specifier = ">=3.0.5" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.3.0" },
+    { name = "uvicorn", extras = ["standard"], specifier = ">=0.32.0" },
+]
+provides-extras = ["dev"]
 
 [[package]]
 name = "librt"


### PR DESCRIPTION
## Summary

- Librarian (L) 첫 구현 — 다른 에이전트들이 Doc Store 에 접근하는 단일 창구
- 자연어 요청 → LLM ReAct → Doc Store MCP tool 호출 → 자연어 응답
- thin pass-through (도메인 wrapper 박지 않음, root CLAUDE.md 원칙 일관)

## 2 commits

| commit | 내용 |
|---|---|
| `<sha1>` | **feat(agent)**: 본체 — graph (ReAct) + tools (17) + server + tests |
| `3455b1e` | **chore(infra)**: librarian compose (port 9002) + override.yaml.example |

## 토폴로지에서의 위치

```mermaid
flowchart LR
    Agents["P / A / ENG / QA"] -->|A2A 자연어 요청| L["Librarian (L)<br/>LLM 추론<br/>자연어 → tool 매핑"]
    L -->|MCP| DocStore["Doc Store MCP<br/>(PostgreSQL JSONB)"]
    L -.M4+.-> Atlas["Atlas MCP<br/>(Neo4j, M4)"]
```

다른 에이전트들은 doc-store 직접 호출 X — 항상 L 통과 (proposal §2.5).

## ReAct 그래프

```mermaid
flowchart LR
    Start([START]) --> llm_call
    llm_call -->|tool_calls 있음| tools
    tools --> llm_call
    llm_call -->|응답 완료| Endd([END])
```

- `llm_call` 노드 — persona + messages → LLM (with `bind_tools`) → AIMessage
- `tools` 노드 — AIMessage.tool_calls 실행 → ToolMessage 반환 (직접 구현, `langgraph.prebuilt.ToolNode` 의존 회피 + 디버깅 명시)
- `_should_continue` — tool_calls 유무로 분기

## 도구 면 — 17 op

Doc Store schema thin pass-through. 도메인 wrapper (`upsert_prd` 등) 박지 않음 (root CLAUDE.md "에이전트 ↔ 외부 도구 운영 원칙"). LLM 이 매 요청 컨텍스트에 맞춰 `page_type` / `type` 결정.

| collection | 노출 op | 비고 |
|---|---|---|
| `wiki_pages` | create / update / get / list / get_by_slug | PRD / ADR / business_rule (`page_type` 필드) |
| `issues` | create / update / get / list | Epic / Story / Task (`type` 필드) |
| `agent_tasks` | get / list | CHR 영속한 작업 단위 |
| `agent_sessions` | get / list / list_by_task / find_by_context | chronicler 로그 entry |
| `agent_items` | list / list_by_session | chronicler 로그 본문 |

`delete` / `count` 미노출 (M3 호출자 불필요).

## 모듈 구조 (Primary 미러)

```
agents/librarian/
├── Dockerfile + pyproject.toml
├── config/base.yaml          # role / persona / llm / agent_card
├── src/librarian_agent/
│   ├── graph.py              # State / build_graph / _make_tool_node / _serialize
│   ├── tools.py              # DocStoreClient closure 캡처 — 17 tools
│   └── server.py             # FastAPI lifespan (MCP client + tools + graph)
├── tests/                    # graph 헬퍼 + tools forwarding (mocked client)
└── scripts/verify_sandbox.{sh,py}  # A2A SSE 통합 검증

overrides/librarian.yaml.example   # ANTHROPIC_API_KEY 만
```

## 환경변수

| 변수 | 의미 |
|---|---|
| `ANTHROPIC_API_KEY` | Primary 와 동일 (overrides 통해 주입) |
| `DOC_STORE_MCP_URL` | 예: `http://doc-store-mcp:8000/mcp` |
| `DATABASE_URI` | LangGraph checkpointer (Postgres `langgraph` DB). 미설정 시 in-memory |

## 호출 예시 (실 sandbox 결과)

자연어 요청:
> "doc-store 의 wiki_pages 를 page_type 무관하게 list 해줘. limit=5 면 충분."

L 의 ReAct 처리:
1. LLM → `wiki_pages_list(limit=5)` tool 호출 결정
2. Doc Store MCP `wiki_pages.list` 호출
3. 결과 (`list[WikiPageRead]`) 받음
4. 자연어 응답 (실 출력):
   > "조회 결과, **현재 Doc Store 의 `wiki_pages` 컬렉션에는 저장된 문서가 없습니다** (빈 배열 반환). 즉, page_type 무관하게 전체를 조회했으나 등록된 위키 페이지가 0건입니다..."

## 본 PR 비-스코프

- **Atlas MCP 도구** (graph 탐색) — M4 #43/#44
- **Diff 색인 / `get_task_context`** — M5+
- **Code 구조 분석** — M5+
- **doc-store SDK composition 리팩터** (현 flat → ISP) — 별 chore (issue_tracker / wiki 와 일관성)
- **다른 에이전트의 L 호출 wiring** — #39 P 그래프 확장 / #45 Architect

## Test plan

- [x] 단위 테스트 17/17 (graph 헬퍼 11 + tools 6, mocked DocStoreClient)
- [x] sandbox 통과 — A2A `SendStreamingMessage` 자연어 → ReAct → tool 호출 → 자연어 응답 (3 시나리오)
- [x] 컨테이너 부팅 + `/healthz` + `/.well-known/agent-card.json` 정상
- [x] 17 tools 등록 확인 + Doc Store MCP 연결 정상
- [x] thin pass-through 원칙 적용 (도메인 wrapper 0)

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)
