### PR TITLE
refactor(librarian): 도구 인터페이스 read 중심 재정의 + chronicler_log_by_context 추가 (#64)

### DIFF
--- a/agents/librarian/config/base.yaml
+++ b/agents/librarian/config/base.yaml
@@ -80,8 +80,8 @@ persona: |
   현재 노출 도구는 Doc Store 5 collection 의 read op + 조합 쿼리 1 개.
   Atlas (graph) MCP 연동, 외부 리소스 조사 3 트랙 (context7 / web-fetch /
   Claude Web Search) 은 후속 마일스톤에서 추가됩니다. Diff 색인은 본
-  에이전트의 책임이 아니며 (Engineer 자체 색인 — #63 옵션 A 확정), Eng
-  자기 변경 diff 를 직접 Atlas / Doc Store MCP 에 write 합니다. 미구현 기능
+  에이전트의 책임이 아니며 (Engineer 자체 색인 — #63 옵션 A 확정), Engineer
+  가 자기 변경 diff 를 직접 Atlas / Doc Store MCP 에 write 합니다. 미구현 기능
   호출이 들어오면 "본 단계에선 미지원" 으로 명시합니다.
 
 llm:

--- a/agents/librarian/config/base.yaml
+++ b/agents/librarian/config/base.yaml
@@ -56,8 +56,9 @@ persona: |
   - mcp/web-fetch — 사용자 제공 URL 의 페이지 (Playwright 기반)
   - Claude Web Search — 일반 web 검색 (Claude API native tool)
 
-  자세한 op 인터페이스는 도구 schema (bind_tools) 를 참조하세요. write 도구
-  (`*_create` / `*_update`) 는 책임 분담 정정 (#63 / #64) 후 제거 / 최소화 예정.
+  자세한 op 인터페이스는 도구 schema (bind_tools) 를 참조하세요. read 13 op
+  + 조합 쿼리 1 (`chronicler_log_by_context`) = 14 op. write 도구는 노출하지
+  않습니다 (#63 분담 모델 — 각 에이전트가 자기 도메인 데이터 MCP 직접 write).
 
   ## 행동 원칙
 
@@ -76,10 +77,12 @@ persona: |
 
   ## 현재 단계 제약 (M3)
 
-  현재 노출 도구는 Doc Store 5 collection 의 일부 op (CRUD 중 read 위주 +
-  필요한 write). Atlas (graph) / 코드 구조 분석 / diff 색인은 M4+ 에서
-  추가됩니다. 미구현 기능 호출이 들어오면 "본 단계에선 미지원" 으로
-  명시합니다.
+  현재 노출 도구는 Doc Store 5 collection 의 read op + 조합 쿼리 1 개.
+  Atlas (graph) MCP 연동, 외부 리소스 조사 3 트랙 (context7 / web-fetch /
+  Claude Web Search) 은 후속 마일스톤에서 추가됩니다. Diff 색인은 본
+  에이전트의 책임이 아니며 (Engineer 자체 색인 — #63 옵션 A 확정), Eng
+  자기 변경 diff 를 직접 Atlas / Doc Store MCP 에 write 합니다. 미구현 기능
+  호출이 들어오면 "본 단계에선 미지원" 으로 명시합니다.
 
 llm:
   provider: anthropic
@@ -111,9 +114,11 @@ agent_card:
     url: https://github.com/vonkernel/dev-team
   skills:
     - id: librarian.doc_store_query
-      name: Doc Store Query / Mutation
+      name: Doc Store Query
       description: |
         자연어 요청을 받아 Doc Store 의 5 collection (wiki_pages / issues /
-        agent_tasks / agent_sessions / agent_items) 의 read/write 도구를
-        호출하고 결과를 자연어로 정리해 응답합니다.
-      tags: [librarian, doc-store, query, mutation, react]
+        agent_tasks / agent_sessions / agent_items) 의 read 도구 + 조합
+        쿼리 (chronicler_log_by_context 등) 를 호출하고 결과를 자연어로
+        정리해 응답합니다. write 는 본 에이전트의 책임이 아닙니다 — 각
+        에이전트가 자기 도메인 데이터를 MCP 통해 직접 write (#63 분담 모델).
+      tags: [librarian, doc-store, query, read, react]

--- a/agents/librarian/scripts/verify_sandbox.py
+++ b/agents/librarian/scripts/verify_sandbox.py
@@ -4,9 +4,10 @@
 대상: A2A `SendStreamingMessage` 로 자연어 요청 → LLM 이 tool 호출 + 자연어 응답
 
 검증 시나리오 (read-only — Doc Store 데이터 변경 X):
-  1. AgentCard 정상
+  1. AgentCard 정상 (skill = read 중심 — #64)
   2. "wiki_pages.list" 자연어 요청 → wiki_pages_list tool 호출 + 자연어 응답
   3. "agent_tasks 몇 개" → agent_tasks_list 호출 + count 응답
+  4. chronicler_log_by_context — 조합 쿼리 (#64 신설)
 """
 
 from __future__ import annotations
@@ -107,6 +108,16 @@ async def main() -> int:
     print("\n[3] 'agent_tasks 몇 개?' (count via list)")
     events = await send_streaming_message(
         "agent_tasks collection 에 현재 몇 개의 task 가 있는지 list 도구로 확인하고 개수만 알려줘.",
+    )
+    final = _extract_final_text(events)
+    print(f"    final text (first 300):\n      {final[:300]!r}")
+    if not final:
+        print("    !! 자연어 응답 없음")
+        return 1
+
+    print("\n[4] chronicler_log_by_context — 임의 contextId 조회 (조합 쿼리)")
+    events = await send_streaming_message(
+        "context_id 'nonexistent-ctx' 의 chronicler 로그를 chronicler_log_by_context 도구로 조회하고 결과 알려줘. (없으면 없다고)",
     )
     final = _extract_final_text(events)
     print(f"    final text (first 300):\n      {final[:300]!r}")

--- a/agents/librarian/src/librarian_agent/tools.py
+++ b/agents/librarian/src/librarian_agent/tools.py
@@ -1,17 +1,21 @@
 """Librarian 의 LangChain tool 정의.
 
-Doc Store 의 5 collection thin pass-through. LangChain `@tool` 로 wrapping 해
-LLM 의 `bind_tools()` 에 부착 — LLM 이 자연어 → tool 매핑 결정.
+Doc Store 의 5 collection read 도구 + 조합 쿼리 1 개. LangChain `@tool` 로
+wrapping 해 LLM 의 `bind_tools()` 에 부착 — LLM 이 자연어 → tool 매핑 결정.
 
 도메인 wrapper (`upsert_prd` 등) 박지 않음 (root CLAUDE.md "에이전트 ↔ 외부
 도구 운영 원칙"). LLM 이 매 요청 컨텍스트에 맞춰 page_type / type 필드 결정.
 
-M3 노출 op (delete / count 미노출 — 호출자 불필요):
-- wiki_pages: create / update / get / list / get_by_slug
-- issues:     create / update / get / list
+분담 모델 (#63 정정 — 2026-05): write 는 각 에이전트가 Doc Store / Atlas
+MCP 직접. **Librarian 은 read-only 사서** — 자연어 / 교차 쿼리 매핑.
+
+M3 노출 op (read 13 + 조합 1 = 14):
+- wiki_pages: get / get_by_slug / list
+- issues: get / list
 - agent_tasks: get / list
 - agent_sessions: get / list / list_by_task / find_by_context
-- agent_items:    list / list_by_session
+- agent_items: list / list_by_session
+- 조합: chronicler_log_by_context (session find + items list 결합)
 """
 
 from __future__ import annotations
@@ -22,17 +26,22 @@ from uuid import UUID
 from dev_team_shared.doc_store import (
     AgentItemRead,
     AgentSessionRead,
-    AgentSessionUpdate,
     AgentTaskRead,
     DocStoreClient,
-    IssueCreate,
     IssueRead,
-    IssueUpdate,
-    WikiPageCreate,
     WikiPageRead,
-    WikiPageUpdate,
 )
 from langchain_core.tools import BaseTool, tool
+from pydantic import BaseModel, ConfigDict
+
+
+class ChroniclerLog(BaseModel):
+    """contextId 1 개의 chronicler 로그 = session + items 결합 결과."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    session: AgentSessionRead | None
+    items: list[AgentItemRead]
 
 
 def build_tools(client: DocStoreClient) -> list[BaseTool]:
@@ -42,18 +51,8 @@ def build_tools(client: DocStoreClient) -> list[BaseTool]:
     """
 
     # ──────────────────────────────────────────────────────────────────
-    # wiki_pages
+    # wiki_pages (read)
     # ──────────────────────────────────────────────────────────────────
-
-    @tool
-    async def wiki_pages_create(doc: WikiPageCreate) -> WikiPageRead:
-        """Create a wiki page (PRD / ADR / business_rule 등). page_type 필드로 분류."""
-        return await client.wiki_page_create(doc)
-
-    @tool
-    async def wiki_pages_update(id: str, patch: WikiPageUpdate) -> WikiPageRead | None:
-        """Update wiki page by id (UUID). 미존재 시 null."""
-        return await client.wiki_page_update(UUID(id), patch)
 
     @tool
     async def wiki_pages_get(id: str) -> WikiPageRead | None:
@@ -78,18 +77,8 @@ def build_tools(client: DocStoreClient) -> list[BaseTool]:
         )
 
     # ──────────────────────────────────────────────────────────────────
-    # issues
+    # issues (read)
     # ──────────────────────────────────────────────────────────────────
-
-    @tool
-    async def issues_create(doc: IssueCreate) -> IssueRead:
-        """Create an issue mirror (Epic / Story / Task 등). type 필드로 분류."""
-        return await client.issue_create(doc)
-
-    @tool
-    async def issues_update(id: str, patch: IssueUpdate) -> IssueRead | None:
-        """Update issue by id (UUID). 미존재 시 null."""
-        return await client.issue_update(UUID(id), patch)
 
     @tool
     async def issues_get(id: str) -> IssueRead | None:
@@ -109,7 +98,7 @@ def build_tools(client: DocStoreClient) -> list[BaseTool]:
         )
 
     # ──────────────────────────────────────────────────────────────────
-    # agent_tasks (read-only at M3)
+    # agent_tasks (read)
     # ──────────────────────────────────────────────────────────────────
 
     @tool
@@ -124,13 +113,13 @@ def build_tools(client: DocStoreClient) -> list[BaseTool]:
         offset: int = 0,
         order_by: str = "created_at DESC",
     ) -> list[AgentTaskRead]:
-        """List agent tasks. CHR 가 영속한 작업 단위 메타."""
+        """List agent tasks. Chronicler 가 영속한 작업 단위 메타."""
         return await client.agent_task_list(
             where=where, limit=limit, offset=offset, order_by=order_by,
         )
 
     # ──────────────────────────────────────────────────────────────────
-    # agent_sessions
+    # agent_sessions (read)
     # ──────────────────────────────────────────────────────────────────
 
     @tool
@@ -161,7 +150,7 @@ def build_tools(client: DocStoreClient) -> list[BaseTool]:
         return await client.agent_session_find_by_context(context_id)
 
     # ──────────────────────────────────────────────────────────────────
-    # agent_items
+    # agent_items (read)
     # ──────────────────────────────────────────────────────────────────
 
     @tool
@@ -181,14 +170,27 @@ def build_tools(client: DocStoreClient) -> list[BaseTool]:
         """List items for a session (UUID). chronicler 로그 본문."""
         return await client.agent_item_list_by_session(UUID(session_id))
 
+    # ──────────────────────────────────────────────────────────────────
+    # 조합 쿼리 (composite read)
+    # ──────────────────────────────────────────────────────────────────
+
+    @tool
+    async def chronicler_log_by_context(context_id: str) -> ChroniclerLog:
+        """contextId 의 chronicler 로그 (session + items) 한 번에 조회.
+
+        `agent_sessions_find_by_context` + `agent_items_list_by_session` 두
+        호출을 합친 조합 쿼리. session 미존재 시 items 는 빈 리스트.
+        """
+        session = await client.agent_session_find_by_context(context_id)
+        if session is None:
+            return ChroniclerLog(session=None, items=[])
+        items = await client.agent_item_list_by_session(session.id)
+        return ChroniclerLog(session=session, items=items)
+
     return [
-        wiki_pages_create,
-        wiki_pages_update,
         wiki_pages_get,
         wiki_pages_get_by_slug,
         wiki_pages_list,
-        issues_create,
-        issues_update,
         issues_get,
         issues_list,
         agent_tasks_get,
@@ -199,7 +201,8 @@ def build_tools(client: DocStoreClient) -> list[BaseTool]:
         agent_sessions_find_by_context,
         agent_items_list,
         agent_items_list_by_session,
+        chronicler_log_by_context,
     ]
 
 
-__all__ = ["build_tools"]
+__all__ = ["build_tools", "ChroniclerLog"]

--- a/agents/librarian/tests/test_tools.py
+++ b/agents/librarian/tests/test_tools.py
@@ -1,4 +1,7 @@
-"""build_tools 단위 테스트 — DocStoreClient mock 으로 tool ↔ client 메서드 매핑 검증."""
+"""build_tools 단위 테스트 — DocStoreClient mock 으로 tool ↔ client 메서드 매핑 검증.
+
+분담 모델 정정 (#63 / #64) 후: write 도구 미노출. read 13 op + 조합 1 = 14 op.
+"""
 
 from __future__ import annotations
 
@@ -12,9 +15,7 @@ from dev_team_shared.doc_store import (
     AgentItemRead,
     AgentSessionRead,
     AgentTaskRead,
-    IssueCreate,
     IssueRead,
-    WikiPageCreate,
     WikiPageRead,
 )
 
@@ -36,13 +37,9 @@ def test_build_tools_returns_expected_tool_names(mock_client) -> None:
     tools = build_tools(mock_client)
     names = sorted(t.name for t in tools)
     assert names == sorted([
-        "wiki_pages_create",
-        "wiki_pages_update",
         "wiki_pages_get",
         "wiki_pages_get_by_slug",
         "wiki_pages_list",
-        "issues_create",
-        "issues_update",
         "issues_get",
         "issues_list",
         "agent_tasks_get",
@@ -53,7 +50,19 @@ def test_build_tools_returns_expected_tool_names(mock_client) -> None:
         "agent_sessions_find_by_context",
         "agent_items_list",
         "agent_items_list_by_session",
+        "chronicler_log_by_context",
     ])
+
+
+def test_build_tools_excludes_write_ops(mock_client) -> None:
+    """write 도구는 #64 시점에 제거. read 사서 정체성 일관."""
+    tools = build_tools(mock_client)
+    names = {t.name for t in tools}
+    forbidden = {
+        "wiki_pages_create", "wiki_pages_update",
+        "issues_create", "issues_update",
+    }
+    assert names.isdisjoint(forbidden)
 
 
 def _wiki_page_read(slug: str = "prd-x") -> WikiPageRead:
@@ -97,40 +106,61 @@ def _issue_read() -> IssueRead:
     )
 
 
+def _agent_session_read(sid: str = "00000000-0000-0000-0000-000000000003") -> AgentSessionRead:
+    return AgentSessionRead(
+        id=UUID(sid),
+        agent_task_id=UUID("00000000-0000-0000-0000-000000000099"),
+        initiator="primary",
+        counterpart="user-gateway",
+        context_id="ctx-1",
+        trace_id=None,
+        topic=None,
+        metadata={},
+        started_at=_now(),
+        ended_at=None,
+    )
+
+
+def _agent_item_read(iid: str = "00000000-0000-0000-0000-000000000010") -> AgentItemRead:
+    return AgentItemRead(
+        id=UUID(iid),
+        agent_session_id=UUID("00000000-0000-0000-0000-000000000003"),
+        prev_item_id=None,
+        role="user",
+        sender="primary",
+        content={"text": "hello"},
+        message_id=None,
+        metadata={},
+        created_at=_now(),
+    )
+
+
 @pytest.mark.asyncio
-async def test_wiki_pages_create_forwards_to_client(mock_client) -> None:
+async def test_wiki_pages_get_forwards_uuid(mock_client) -> None:
     tools = {t.name: t for t in build_tools(mock_client)}
     expected = _wiki_page_read()
-    mock_client.wiki_page_create = AsyncMock(return_value=expected)
+    mock_client.wiki_page_get = AsyncMock(return_value=expected)
 
-    doc = WikiPageCreate(
-        agent_task_id=UUID("00000000-0000-0000-0000-000000000099"),
-        page_type="prd",
-        slug="prd-x",
-        title="PRD X",
-        content_md="# body",
-        author_agent="primary",
-    )
-    result = await tools["wiki_pages_create"].ainvoke({"doc": doc})
+    pid = "00000000-0000-0000-0000-000000000001"
+    result = await tools["wiki_pages_get"].ainvoke({"id": pid})
     assert result == expected
-    mock_client.wiki_page_create.assert_awaited_once_with(doc)
+    mock_client.wiki_page_get.assert_awaited_once_with(UUID(pid))
 
 
 @pytest.mark.asyncio
-async def test_issues_create_forwards_to_client(mock_client) -> None:
+async def test_issues_list_forwards_args(mock_client) -> None:
     tools = {t.name: t for t in build_tools(mock_client)}
-    expected = _issue_read()
-    mock_client.issue_create = AsyncMock(return_value=expected)
+    mock_client.issue_list = AsyncMock(return_value=[_issue_read()])
 
-    doc = IssueCreate(
-        agent_task_id=UUID("00000000-0000-0000-0000-000000000099"),
-        type="epic",
-        title="Epic 1",
-        body_md="...",
+    await tools["issues_list"].ainvoke({
+        "where": {"type": "epic"},
+        "limit": 50,
+        "offset": 0,
+        "order_by": "created_at DESC",
+    })
+    mock_client.issue_list.assert_awaited_once_with(
+        where={"type": "epic"}, limit=50, offset=0, order_by="created_at DESC",
     )
-    result = await tools["issues_create"].ainvoke({"doc": doc})
-    assert result == expected
-    mock_client.issue_create.assert_awaited_once_with(doc)
 
 
 @pytest.mark.asyncio
@@ -167,3 +197,40 @@ async def test_wiki_pages_list_forwards_args(mock_client) -> None:
     mock_client.wiki_page_list.assert_awaited_once_with(
         where={"page_type": "prd"}, limit=50, offset=0, order_by="created_at DESC",
     )
+
+
+# ──────────────────────────────────────────────────────────────────
+# chronicler_log_by_context (composite read — #64)
+# ──────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_chronicler_log_by_context_combines_session_and_items(mock_client) -> None:
+    """session 존재 → find_by_context + list_by_session 두 번 호출 후 결합."""
+    tools = {t.name: t for t in build_tools(mock_client)}
+    session = _agent_session_read()
+    items = [_agent_item_read()]
+    mock_client.agent_session_find_by_context = AsyncMock(return_value=session)
+    mock_client.agent_item_list_by_session = AsyncMock(return_value=items)
+
+    result = await tools["chronicler_log_by_context"].ainvoke({"context_id": "ctx-1"})
+
+    assert result.session == session
+    assert result.items == items
+    mock_client.agent_session_find_by_context.assert_awaited_once_with("ctx-1")
+    mock_client.agent_item_list_by_session.assert_awaited_once_with(session.id)
+
+
+@pytest.mark.asyncio
+async def test_chronicler_log_by_context_returns_empty_when_session_missing(mock_client) -> None:
+    """session 미존재 → list_by_session 호출 X. items 빈 리스트."""
+    tools = {t.name: t for t in build_tools(mock_client)}
+    mock_client.agent_session_find_by_context = AsyncMock(return_value=None)
+    mock_client.agent_item_list_by_session = AsyncMock(return_value=[])
+
+    result = await tools["chronicler_log_by_context"].ainvoke({"context_id": "ctx-missing"})
+
+    assert result.session is None
+    assert result.items == []
+    mock_client.agent_session_find_by_context.assert_awaited_once_with("ctx-missing")
+    mock_client.agent_item_list_by_session.assert_not_awaited()


### PR DESCRIPTION
## Summary

#63 (데이터 접근 분담 모델 정정) 의 후속 코드 작업. Librarian = "사서 (정보 검색 + 외부 리소스 조사)" 정체성에 맞춰 도구 인터페이스 정리.

**17 op → 14 op**:
- write 도구 4 op 제거 (`wiki_pages_create` / `wiki_pages_update` / `issues_create` / `issues_update`) — 각 에이전트가 자기 도메인 데이터를 MCP 직접 write
- 조합 쿼리 1 op 신설 (`chronicler_log_by_context`) — `agent_sessions.find_by_context` + `agent_items.list_by_session` 결합
- read 13 op 유지

## 변경 내역

### tools.py
- `WikiPageCreate` / `WikiPageUpdate` / `IssueCreate` / `IssueUpdate` import 제거
- `wiki_pages_create` / `wiki_pages_update` / `issues_create` / `issues_update` 4 함수 제거
- `ChroniclerLog` Pydantic 모델 신설 (`session: AgentSessionRead | None`, `items: list[AgentItemRead]`)
- `chronicler_log_by_context(context_id) → ChroniclerLog` 신설
- module docstring 을 read 중심 사서 정체성 + 14 op 카탈로그로 갱신

### tests/test_tools.py
- `expected tool names` 표를 14 op 로 갱신
- `test_build_tools_excludes_write_ops` 가드 신설 — write op 미노출 보장
- `chronicler_log_by_context` 의 session 존재 / 미존재 케이스 2 테스트 추가
- 제거된 write op 의 forwarding 테스트 삭제

### config/base.yaml
- `agent_card.skills` description: `Doc Store Query / Mutation` → `Doc Store Query` (read 중심) + `chronicler_log_by_context` 명시 + write 미노출 사실 명시
- persona 도구 카탈로그 단락: write 도구 제거 사실 확정 + 조합 쿼리 1 개 신설 명시
- persona "현재 단계 제약" 단락: Diff 색인은 본 에이전트 책임 아님 (Engineer 자체 색인 — #63 옵션 A 확정) 명시

### scripts/verify_sandbox.py
- 자연어 시나리오 [4] 추가 — `chronicler_log_by_context` 호출 검증

## 검증

- `uv run pytest` — 20 통과 (graph_helpers 11 + tools 9)
- `excludes_write_ops` 가드로 향후 write op 재유입 회귀 방지
- 도구 14 op 등록 확인 (`test_build_tools_returns_expected_tool_names`)
- sandbox: `bash agents/librarian/scripts/verify_sandbox.sh` 로 4 시나리오 자연어 응답 확인 (Doc Store + Librarian 컨테이너 부팅 후)

## 비-스코프 (이슈 #64 명시)

- `recent_activity` / `search_pages` 같은 추가 복합 도구 — M5+
- Librarian 의 LLM 모델 / 비용 최적화 — M5+

## 후속

- #39 — Primary 그래프 확장 (multi-MCP wiring) — 본 PR 머지 후 새 정책 위에서

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)
