### PR TITLE
feat(shared/a2a): graph entry partial state sanity (#73)

### DIFF
--- a/shared/src/dev_team_shared/a2a/server/graph_handlers/__init__.py
+++ b/shared/src/dev_team_shared/a2a/server/graph_handlers/__init__.py
@@ -19,6 +19,7 @@ sentinel 처리를 함께 수행한다.
   factories         A2A Task / 이벤트 모델 조립 + 에러 텍스트
   envelope          JSON-RPC / SSE envelope 직렬화
   stream            graph.astream → SSE 라인 번역
+  sanity            graph 호출 전 messages tail dangling 정리 (#73)
   send_message      GraphSendMessageHandler (단방향)
   send_streaming    GraphSendStreamingMessageHandler (SSE)
 

--- a/shared/src/dev_team_shared/a2a/server/graph_handlers/sanity.py
+++ b/shared/src/dev_team_shared/a2a/server/graph_handlers/sanity.py
@@ -1,0 +1,127 @@
+"""Graph 진입 직전 messages tail 의 dangling 패턴 감지 + marker 추가.
+
+Cancel / 외부 proxy timeout 등으로 LangGraph 그래프가 응답을 끝내지 못한
+상태에서 다음 turn 이 시작되면 messages channel 에 다음 3 가지 잔재가 남는다:
+
+    A. user-user adjacency      — assistant 응답 없이 user 메시지가 연속
+    B. trailing ToolMessage     — tool 결과 후 닫는 AIMessage 부재
+    C. trailing AIMessage(tool_calls) without matching ToolMessage(s)
+                                  — Anthropic API 의 tool_use → tool_result
+                                    형식 검사에서 거부됨 (실패 hard-fail)
+
+본 모듈은 graph 호출 직전에 latest checkpoint 의 messages tail 을 보고,
+각 패턴에 대해 명시 marker 메시지를 append 한다. tail-only 검사 — 매 turn
+시작 시 호출하면 mid-history 까지 누적될 수 없다 (turn 마다 정리되므로).
+
+핸들러 (`send_message`, `send_streaming`) 가 graph 호출 직전에
+`apply_tail_sanity(graph, config)` 를 호출.
+
+Pattern 분류:
+- A 는 LLM tolerable 하지만 의미 차이를 나타낼 SystemMessage marker 추가.
+- B 는 LLM 이 dangling tool result 를 어떻게 다룰지 알도록 placeholder
+  AIMessage 추가.
+- C 는 **API 차원 hard 요구사항** — placeholder ToolMessage 가 없으면 LLM
+  호출 자체가 실패. 본 모듈의 가장 critical 한 책임.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from langchain_core.messages import (
+    AIMessage,
+    AnyMessage,
+    HumanMessage,
+    SystemMessage,
+    ToolMessage,
+)
+
+logger = logging.getLogger(__name__)
+
+USER_DANGLING_MARKER = (
+    "[직전 turn 의 응답이 도중에 중단되어, 위 사용자 발화가 응답 없이 누적됨. "
+    "다음 발화와 함께 종합해 응답하라.]"
+)
+TOOL_RESULT_DANGLING_MARKER = (
+    "[직전 turn 의 응답이 도구 결과 후 중단됨. 다음 발화에 응답할 때 이 결과를 "
+    "반영하라.]"
+)
+TOOL_CALL_INTERRUPTED = "[tool call interrupted before completion]"
+
+
+def detect_tail_markers(msgs: list[AnyMessage]) -> list[AnyMessage]:
+    """tail dangling 패턴을 감지해 append 할 marker 메시지 목록 반환.
+
+    호출자는 결과를 graph state 의 messages channel 에 append 한 뒤 새 user
+    입력을 invoke. marker 가 새 입력 앞에 위치해 LLM context 형태가 정상화.
+
+    빈 목록 반환 = tail 깨끗 (또는 첫 turn).
+    """
+    if not msgs:
+        return []
+    last = msgs[-1]
+
+    if isinstance(last, HumanMessage):
+        # Pattern A: 직전이 또 HumanMessage 이면 user-user adjacency.
+        # 단일 trailing HumanMessage 는 정상 (이번 turn 의 입력 — 다만 본
+        # 헬퍼는 graph 호출 직전 호출되므로 실제로는 있을 수 없는 형태).
+        if len(msgs) >= 2 and isinstance(msgs[-2], HumanMessage):
+            return [SystemMessage(content=USER_DANGLING_MARKER)]
+        return []
+
+    if isinstance(last, ToolMessage):
+        # Pattern B: tool 결과 직후 cancel — 닫는 AIMessage 부재.
+        return [AIMessage(content=TOOL_RESULT_DANGLING_MARKER)]
+
+    if isinstance(last, AIMessage) and last.tool_calls:
+        # Pattern C: tool_calls 결정 직후 cancel — ToolMessage 부재.
+        # tail 의 AIMessage 의 모든 tool_call 이 unanswered (정상 이라면 그
+        # 직후에 ToolMessage 들이 와야 하므로). 각각에 placeholder 생성.
+        return [
+            ToolMessage(
+                content=TOOL_CALL_INTERRUPTED,
+                tool_call_id=tc.get("id", ""),
+                name=tc.get("name", ""),
+            )
+            for tc in last.tool_calls
+        ]
+
+    # 정상 AIMessage tail (자연어 응답 완료) — 정리할 게 없음.
+    return []
+
+
+async def apply_tail_sanity(graph: Any, config: dict[str, Any]) -> int:
+    """Graph 의 latest checkpoint 에 sanity marker 를 append.
+
+    Args:
+        graph: CompiledStateGraph (`aget_state` / `aupdate_state` 지원).
+        config: `{"configurable": {"thread_id": ...}}`.
+
+    Returns:
+        추가된 marker 개수. 0 이면 깨끗 (또는 첫 turn).
+    """
+    state = await graph.aget_state(config)
+    if state is None or not state.values:
+        return 0
+    msgs = state.values.get("messages") or []
+    markers = detect_tail_markers(msgs)
+    if not markers:
+        return 0
+    await graph.aupdate_state(config, {"messages": markers})
+    logger.info(
+        "graph_sanity.tail_markers_applied thread_id=%s count=%d patterns=%s",
+        config.get("configurable", {}).get("thread_id"),
+        len(markers),
+        [type(m).__name__ for m in markers],
+    )
+    return len(markers)
+
+
+__all__ = [
+    "TOOL_CALL_INTERRUPTED",
+    "TOOL_RESULT_DANGLING_MARKER",
+    "USER_DANGLING_MARKER",
+    "apply_tail_sanity",
+    "detect_tail_markers",
+]

--- a/shared/src/dev_team_shared/a2a/server/graph_handlers/send_message.py
+++ b/shared/src/dev_team_shared/a2a/server/graph_handlers/send_message.py
@@ -27,6 +27,7 @@ from dev_team_shared.a2a.server.graph_handlers.parse import (
     parse_request_or_error,
 )
 from dev_team_shared.a2a.server.graph_handlers.publish import publish_item_append
+from dev_team_shared.a2a.server.graph_handlers.sanity import apply_tail_sanity
 from dev_team_shared.a2a.server.graph_handlers.session import ChatContext, log_session
 from dev_team_shared.a2a.server.handler import MethodHandler
 
@@ -66,6 +67,11 @@ class GraphSendMessageHandler(MethodHandler):
                 sender="user",
                 content=[p.model_dump(mode="json") for p in a2a_msg.parts],
                 message_id=a2a_msg.message_id,
+            )
+            # Graph 호출 직전 sanity — send_streaming.py 와 동일 정책.
+            await apply_tail_sanity(
+                request.app.state.graph,
+                {"configurable": {"thread_id": ctx.context_id}},
             )
             try:
                 with anyio.fail_after(AGENT_TOTAL_TIMEOUT_S):  # S4

--- a/shared/src/dev_team_shared/a2a/server/graph_handlers/send_streaming.py
+++ b/shared/src/dev_team_shared/a2a/server/graph_handlers/send_streaming.py
@@ -33,6 +33,7 @@ from dev_team_shared.a2a.server.graph_handlers.factories import (
 )
 from dev_team_shared.a2a.server.graph_handlers.parse import parse_request_or_error
 from dev_team_shared.a2a.server.graph_handlers.publish import publish_item_append
+from dev_team_shared.a2a.server.graph_handlers.sanity import apply_tail_sanity
 from dev_team_shared.a2a.server.graph_handlers.session import ChatContext, log_session
 from dev_team_shared.a2a.server.graph_handlers.stream import stream_artifact_events
 from dev_team_shared.a2a.server.handler import MethodHandler
@@ -80,6 +81,12 @@ class GraphSendStreamingMessageHandler(MethodHandler):
                     message_id=a2a_msg.message_id,
                 )
                 yield sse(ctx, make_initial_task(ctx, a2a_msg))
+                # Graph 호출 직전 sanity — 직전 turn 이 cancel 로 dangling
+                # 잔재를 남겼다면 marker 를 append (Anthropic API 의 tool_use
+                # ↔ tool_result 형식 검사 hard-fail 회피 + LLM context 정상화).
+                await apply_tail_sanity(
+                    graph, {"configurable": {"thread_id": ctx.context_id}},
+                )
                 try:
                     with anyio.fail_after(AGENT_TOTAL_TIMEOUT_S):  # S4
                         async for line in stream_artifact_events(

--- a/shared/tests/test_a2a_graph_sanity.py
+++ b/shared/tests/test_a2a_graph_sanity.py
@@ -1,0 +1,235 @@
+"""Graph entry sanity (#73) 단위 테스트.
+
+`detect_tail_markers` 의 3 가지 dangling 패턴 + 정상 tail / 빈 history 처리.
+`apply_tail_sanity` 는 InMemorySaver + 작은 graph 로 통합.
+"""
+
+from __future__ import annotations
+
+import pytest
+from dev_team_shared.a2a.server.graph_handlers.sanity import (
+    TOOL_CALL_INTERRUPTED,
+    TOOL_RESULT_DANGLING_MARKER,
+    USER_DANGLING_MARKER,
+    apply_tail_sanity,
+    detect_tail_markers,
+)
+from langchain_core.messages import (
+    AIMessage,
+    AnyMessage,
+    HumanMessage,
+    SystemMessage,
+    ToolMessage,
+)
+from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.graph import END, START, StateGraph
+from langgraph.graph.message import add_messages
+from typing_extensions import Annotated, TypedDict
+
+
+class _State(TypedDict):
+    messages: Annotated[list[AnyMessage], add_messages]
+
+
+def _identity_node(state: _State) -> dict[str, list[AnyMessage]]:
+    return {"messages": []}
+
+
+def _build_graph():  # type: ignore[no-untyped-def]
+    """Sanity 통합 테스트용 최소 graph (1 노드, no LLM)."""
+    builder = StateGraph(_State)
+    builder.add_node("identity", _identity_node)
+    builder.add_edge(START, "identity")
+    builder.add_edge("identity", END)
+    return builder.compile(checkpointer=InMemorySaver())
+
+
+# ─────────────────────────────────────────────────────────────────────────
+#  detect_tail_markers — 단위
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestDetectTailMarkers:
+    def test_empty_returns_empty(self) -> None:
+        assert detect_tail_markers([]) == []
+
+    def test_single_user_msg_is_clean(self) -> None:
+        # 첫 turn 의 입력 직후 — 정상 (단일 trailing user)
+        assert detect_tail_markers([HumanMessage(content="hi")]) == []
+
+    def test_user_user_adjacency_marker(self) -> None:
+        # Pattern A: assistant 응답 누락된 채 user 가 연속
+        msgs = [
+            AIMessage(content="hello"),
+            HumanMessage(content="첫 발화"),
+            HumanMessage(content="둘째 발화 (응답 못 받음)"),
+        ]
+        markers = detect_tail_markers(msgs)
+        assert len(markers) == 1
+        assert isinstance(markers[0], SystemMessage)
+        assert markers[0].content == USER_DANGLING_MARKER
+
+    def test_user_after_ai_is_clean(self) -> None:
+        # 정상: AI → User (이번 turn 의 입력)
+        msgs = [
+            AIMessage(content="hello"),
+            HumanMessage(content="첫 발화"),
+        ]
+        assert detect_tail_markers(msgs) == []
+
+    def test_trailing_tool_message_marker(self) -> None:
+        # Pattern B: tool 결과 후 닫는 AI 부재
+        msgs = [
+            HumanMessage(content="search"),
+            AIMessage(content="", tool_calls=[
+                {"id": "call_1", "name": "search", "args": {}},
+            ]),
+            ToolMessage(content="result", tool_call_id="call_1", name="search"),
+        ]
+        markers = detect_tail_markers(msgs)
+        assert len(markers) == 1
+        assert isinstance(markers[0], AIMessage)
+        assert markers[0].content == TOOL_RESULT_DANGLING_MARKER
+
+    def test_trailing_ai_with_tool_calls_marker_per_call(self) -> None:
+        # Pattern C: tool_calls 결정 직후 cancel — Anthropic API hard requirement
+        msgs = [
+            HumanMessage(content="do two things"),
+            AIMessage(content="", tool_calls=[
+                {"id": "call_a", "name": "tool_a", "args": {}},
+                {"id": "call_b", "name": "tool_b", "args": {"x": 1}},
+            ]),
+        ]
+        markers = detect_tail_markers(msgs)
+        assert len(markers) == 2
+        assert all(isinstance(m, ToolMessage) for m in markers)
+        assert markers[0].tool_call_id == "call_a"  # type: ignore[union-attr]
+        assert markers[0].name == "tool_a"  # type: ignore[union-attr]
+        assert markers[0].content == TOOL_CALL_INTERRUPTED  # type: ignore[union-attr]
+        assert markers[1].tool_call_id == "call_b"  # type: ignore[union-attr]
+        assert markers[1].name == "tool_b"  # type: ignore[union-attr]
+
+    def test_clean_ai_tail_returns_empty(self) -> None:
+        # 정상 종료 — final AI text 응답
+        msgs = [
+            HumanMessage(content="안녕"),
+            AIMessage(content="안녕하세요!"),
+        ]
+        assert detect_tail_markers(msgs) == []
+
+    def test_ai_without_tool_calls_is_clean(self) -> None:
+        # AIMessage 에 tool_calls 가 빈 목록인 경우도 정상으로 본다
+        msgs = [
+            HumanMessage(content="hi"),
+            AIMessage(content="hello", tool_calls=[]),
+        ]
+        assert detect_tail_markers(msgs) == []
+
+
+# ─────────────────────────────────────────────────────────────────────────
+#  apply_tail_sanity — 통합 (InMemorySaver)
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestApplyTailSanity:
+    @pytest.mark.asyncio
+    async def test_no_state_is_noop(self) -> None:
+        graph = _build_graph()
+        config = {"configurable": {"thread_id": "fresh-thread"}}
+        n = await apply_tail_sanity(graph, config)
+        assert n == 0
+
+    @pytest.mark.asyncio
+    async def test_clean_state_is_noop(self) -> None:
+        graph = _build_graph()
+        config = {"configurable": {"thread_id": "clean-thread"}}
+        # 1 turn 정상 진행
+        await graph.ainvoke(
+            {"messages": [HumanMessage(content="hi"), AIMessage(content="hello")]},
+            config=config,
+        )
+        n = await apply_tail_sanity(graph, config)
+        assert n == 0
+
+    @pytest.mark.asyncio
+    async def test_user_user_state_appends_marker(self) -> None:
+        graph = _build_graph()
+        config = {"configurable": {"thread_id": "user-user-thread"}}
+        # dangling user-user 시뮬레이션
+        await graph.ainvoke(
+            {"messages": [
+                AIMessage(content="hi"),
+                HumanMessage(content="첫"),
+                HumanMessage(content="둘째"),
+            ]},
+            config=config,
+        )
+        n = await apply_tail_sanity(graph, config)
+        assert n == 1
+        # 결과 state 확인
+        state = await graph.aget_state(config)
+        msgs = state.values["messages"]
+        assert isinstance(msgs[-1], SystemMessage)
+        assert msgs[-1].content == USER_DANGLING_MARKER
+
+    @pytest.mark.asyncio
+    async def test_trailing_tool_state_appends_ai_marker(self) -> None:
+        graph = _build_graph()
+        config = {"configurable": {"thread_id": "tool-tail-thread"}}
+        await graph.ainvoke(
+            {"messages": [
+                HumanMessage(content="search"),
+                AIMessage(content="", tool_calls=[
+                    {"id": "call_1", "name": "search", "args": {}},
+                ]),
+                ToolMessage(content="result", tool_call_id="call_1", name="search"),
+            ]},
+            config=config,
+        )
+        n = await apply_tail_sanity(graph, config)
+        assert n == 1
+        state = await graph.aget_state(config)
+        last = state.values["messages"][-1]
+        assert isinstance(last, AIMessage)
+        assert last.content == TOOL_RESULT_DANGLING_MARKER
+
+    @pytest.mark.asyncio
+    async def test_unanswered_tool_calls_appends_placeholders(self) -> None:
+        graph = _build_graph()
+        config = {"configurable": {"thread_id": "tool-call-thread"}}
+        await graph.ainvoke(
+            {"messages": [
+                HumanMessage(content="do two"),
+                AIMessage(content="", tool_calls=[
+                    {"id": "x", "name": "tool_x", "args": {}},
+                    {"id": "y", "name": "tool_y", "args": {}},
+                ]),
+            ]},
+            config=config,
+        )
+        n = await apply_tail_sanity(graph, config)
+        assert n == 2
+        state = await graph.aget_state(config)
+        msgs = state.values["messages"]
+        # 마지막 두 메시지가 placeholder ToolMessage
+        assert isinstance(msgs[-2], ToolMessage)
+        assert isinstance(msgs[-1], ToolMessage)
+        assert {msgs[-2].tool_call_id, msgs[-1].tool_call_id} == {"x", "y"}
+
+    @pytest.mark.asyncio
+    async def test_idempotent_after_apply(self) -> None:
+        graph = _build_graph()
+        config = {"configurable": {"thread_id": "idempotent-thread"}}
+        await graph.ainvoke(
+            {"messages": [
+                AIMessage(content="hi"),
+                HumanMessage(content="첫"),
+                HumanMessage(content="둘째"),
+            ]},
+            config=config,
+        )
+        n1 = await apply_tail_sanity(graph, config)
+        n2 = await apply_tail_sanity(graph, config)
+        assert n1 == 1
+        # 두 번째 호출은 tail 이 SystemMessage 라 dangling 패턴 아님 → no-op
+        assert n2 == 0


### PR DESCRIPTION
## Summary

LangGraph 그래프가 응답을 끝내지 못한 상태에서 (cancel / 외부 proxy timeout 등) 다음 turn 시작 시 messages tail 의 dangling 잔재를 marker 로 정리. shared/a2a 의 핸들러 layer 에 적용 — **모든 에이전트가 즉시 보호받음**.

## 3 dangling 패턴

[#39](https://github.com/vonkernel/dev-team/issues/39) 검증 thread 의 messages 채널 디코드에서 발견:

| 패턴 | 위험 | Marker |
|---|---|---|
| **A** user-user adjacency | LLM 이 첫 user 의도 합치거나 무시 — felt "꼬임" | `SystemMessage("[직전 turn 응답 중단됨, 함께 종합해 답하라]")` |
| **B** trailing ToolMessage | 닫는 AIMessage 부재 → LLM context 형태 깨짐 | `AIMessage("[직전 turn 응답이 도구 결과 후 중단됨]")` |
| **C** trailing AIMessage(tool_calls) without matching ToolMessage | **Anthropic API 의 tool_use ↔ tool_result hard 요구사항 — 위반 시 LLM 호출 자체 실패** | unanswered tool_call 별 `ToolMessage("[tool call interrupted before completion]", tool_call_id=...)` |

C 가 가장 critical (API 차원 hard-fail), A/B 는 LLM tolerable 하지만 의미 명확화.

## 설계 — tail-only / append-only / handler layer

`shared/src/dev_team_shared/a2a/server/graph_handlers/sanity.py` 신설:

- `detect_tail_markers(msgs) -> list[AnyMessage]` — 순수 함수, tail 검사. dangling 패턴별 marker 반환 (또는 `[]`).
- `apply_tail_sanity(graph, config) -> int` — graph state 의 latest checkpoint 에 marker append. 추가 개수 반환 (0 = 깨끗).

**Tail-only**: 매 turn 시작 시 호출되므로 mid-history 까지 dangling 이 누적될 수 없음. middle 검사 / 복잡한 RemoveMessage 불필요.

**Append-only**: `add_messages` reducer 의 자연 동작과 충돌 없음. marker 가 새 user 입력 앞에 위치 → LLM context 정상화.

**Handler layer**: graph 노드가 아니라 핸들러에서 graph 호출 직전 적용 — 모든 에이전트 (Primary / Librarian / 향후 Architect / Engineer / QA) 가 무료로 받음. graph 코드 수정 0.

### 통합 지점

- `send_streaming.py` — `stream_artifact_events` 호출 직전
- `send_message.py` — `graph.ainvoke` 직전

## 검증

### 단위 + 통합 (14 테스트)

`shared/tests/test_a2a_graph_sanity.py`:

- `detect_tail_markers` (8) — 3 패턴 + 정상 tail / 빈 history / 단일 user / clean AI
- `apply_tail_sanity` InMemorySaver 통합 (6) — no-state / clean state / 각 패턴 / idempotent

### 회귀 (기존 테스트)

- shared **69 통과** (sanity 14 + 기존 55)
- primary **23 통과**
- librarian **20 통과**

### 실 stack 부팅

- `docker compose --profile agents up -d primary librarian` — 정상 부팅
- Primary lifespan: `primary tools wired: doc_store=on, issue_tracker=on, wiki=on, librarian=on, total=23`
- 양쪽 `/healthz` 200

## 비-스코프

- Mid-history dangling 정리 — tail-only 정책으로 sufficient (turn 마다 sanity 가 호출돼 누적될 수 없음). 만약 본 PR land 전 누적된 mid-history 잔재가 있다면 다음 turn 시작 시 tail 부분만 정리됨 — 이전 잔재는 LLM 이 persona 가이드 기반 처리.
- LangGraph `pre_model_hook` (매 LLM 호출 직전 sanity) — handler layer 적용으로 충분. ReAct 루프 안 dangling 이 발견되면 추후 추가 가능.

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)
